### PR TITLE
Fix image spacing and border propagation on Enter

### DIFF
--- a/src/layout-painter/renderParagraph.ts
+++ b/src/layout-painter/renderParagraph.ts
@@ -326,6 +326,11 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   img.src = run.src;
   img.width = run.width;
   img.height = run.height;
+  // Global CSS reset (Tailwind preflight) sets img { display: block },
+  // which makes text-align: center on the container ineffective.
+  // Use margin: auto on the img itself to center it.
+  img.style.marginLeft = 'auto';
+  img.style.marginRight = 'auto';
   if (run.alt) {
     img.alt = run.alt;
   }

--- a/src/prosemirror/editor.css
+++ b/src/prosemirror/editor.css
@@ -314,6 +314,12 @@
   clear: both;
 }
 
+/* Paragraphs containing only a block image: remove text-indent and center */
+.prosemirror-editor .ProseMirror p:has(> img.docx-image-block:only-child) {
+  text-indent: 0 !important;
+  text-align: center;
+}
+
 /* Clear floats after paragraphs containing floated images */
 .prosemirror-editor .ProseMirror p:has(img.docx-image-float)::after {
   content: '';

--- a/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -118,10 +118,10 @@ export const ImageExtension = createNodeExtension({
         styles.push('margin-right: auto');
         domAttrs.class += ' docx-image-block';
 
-        const marginTop = attrs.distTop ?? 8;
-        const marginBottom = attrs.distBottom ?? 8;
-        styles.push(`margin-top: ${marginTop}px`);
-        styles.push(`margin-bottom: ${marginBottom}px`);
+        const marginTop = attrs.distTop ?? 0;
+        const marginBottom = attrs.distBottom ?? 0;
+        if (marginTop > 0) styles.push(`margin-top: ${marginTop}px`);
+        if (marginBottom > 0) styles.push(`margin-bottom: ${marginBottom}px`);
       }
 
       if (attrs.transform) {


### PR DESCRIPTION
## Summary
- **Fixes #16** — Pressing Enter in a bordered header no longer propagates the border (black underline) to the new paragraph. Custom `splitBlockClearBorders` command clears `w:pBdr` on the new paragraph, matching Word behavior.
- **Fixes #17** — Images no longer have excessive whitespace above/below. `distT/distB/distL/distR` attributes are now read from `wp:anchor` and `wp:inline` elements (not just wrap children). Default block image margins changed from 8px to 0px.
- **Block image centering** — Block images (`topAndBottom` wrap) are now horizontally centered using `margin: auto` in the layout painter. Tailwind's CSS reset sets `img { display: block }` which broke the previous `text-align: center` approach.

## Files changed
| File | Change |
|------|--------|
| `BaseKeymapExtension.ts` | Custom Enter handler that clears borders on new paragraph |
| `imageParser.ts` | Read distance attrs from anchor/inline elements |
| `ImageExtension.ts` | Default block margins 8→0px |
| `renderParagraph.ts` | `margin: auto` on block images for centering |
| `editor.css` | Centering CSS for hidden ProseMirror block images |

## Test plan
- [x] `bun run typecheck` passes
- [x] All 6 Enter-key tests pass (`text-editing.spec.ts`)
- [x] Visually verified #16 fix in Chrome — new paragraph after bordered header has no border
- [x] Visually verified block image centering in Chrome — green dot centered in demo.docx

🤖 Generated with [Claude Code](https://claude.com/claude-code)