### PR TITLE
Fix: show text cursor when hovering over page content

### DIFF
--- a/src/prosemirror/editor.css
+++ b/src/prosemirror/editor.css
@@ -599,6 +599,11 @@
   z-index: 50;
 }
 
+/* Page content area — show text cursor when hovering over editable content */
+.layout-page-content {
+  cursor: text;
+}
+
 /* Header/footer areas — double-click hint */
 .layout-page-header,
 .layout-page-footer {


### PR DESCRIPTION
## Summary
- Fixes #15 — Hovering over text now shows the I-beam caret cursor instead of the default arrow pointer
- Added `cursor: text` to `.layout-page-content`, matching Google Docs behavior

## Reproduction
**Before:** Hovering over text in the editor showed the default arrow cursor (`cursor: default` on all layout elements)
**After:** Hovering over text shows the text selection caret cursor (`cursor: text` on `.layout-page-content`)

Google Docs reference: `.kix-canvas-tile-content { cursor: text }`

## Verification
Confirmed via Chrome DevTools: `.layout-page-content` computed style → `cursor: text`

![fix-confirmed](https://github.com/user-attachments/assets/2d4be6f4-1f5e-4fa0-8610-e93dbea3fdc3)

## Test plan
- [x] `bun run typecheck` passes
- [x] Cursor shows I-beam when hovering over text content
- [x] Header/footer areas retain `cursor: pointer` (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)