### PR TITLE
feat: improve mobile rendering and loading indicator

### DIFF
--- a/examples/vite/index.html
+++ b/examples/vite/index.html
@@ -30,10 +30,24 @@
     }
     .loading {
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      color: #666;
+      color: #94a3b8;
+      gap: 16px;
+      font-size: 14px;
+    }
+    .loading-spinner {
+      width: 36px;
+      height: 36px;
+      border: 3px solid #e2e8f0;
+      border-top-color: #3b82f6;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
     }
 
     /* Hide Material Symbols text until font loads */
@@ -77,7 +91,10 @@
 </head>
 <body>
   <div id="app">
-    <div class="loading">Loading DOCX Editor...</div>
+    <div class="loading">
+      <div class="loading-spinner"></div>
+      <span>Loading editor...</span>
+    </div>
   </div>
   <script type="module" src="./src/main.tsx"></script>
 </body>

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -16,17 +16,20 @@ const styles: Record<string, React.CSSProperties> = {
     overflow: 'hidden',
     background: '#f8fafc',
   },
+  // Desktop header - single row
   header: {
     display: 'flex',
     alignItems: 'center',
-    padding: '12px 20px',
+    padding: '8px 16px',
+    gap: '12px',
     background: '#fff',
     borderBottom: '1px solid #e2e8f0',
   },
   headerLeft: {
     display: 'flex',
     alignItems: 'center',
-    gap: '12px',
+    gap: '8px',
+    flexShrink: 0,
   },
   headerCenter: {
     flex: 1,
@@ -37,17 +40,42 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
+    flexShrink: 0,
   },
-
+  // Mobile header - stacked rows
+  mobileHeader: {
+    display: 'flex',
+    flexDirection: 'column',
+    background: '#fff',
+    borderBottom: '1px solid #e2e8f0',
+  },
+  mobileHeaderTop: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: '6px 10px',
+    gap: '6px',
+  },
+  mobileHeaderFileName: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '4px 10px',
+    borderTop: '1px solid #f1f5f9',
+    position: 'relative',
+  },
   fileName: {
     fontSize: '13px',
     color: '#64748b',
     padding: '4px 10px',
     background: '#f1f5f9',
     borderRadius: '6px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: '200px',
   },
   fileInputLabel: {
-    padding: '8px 14px',
+    padding: '6px 12px',
     background: '#0f172a',
     color: '#fff',
     borderRadius: '6px',
@@ -55,12 +83,13 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '13px',
     fontWeight: 500,
     transition: 'background 0.15s',
+    whiteSpace: 'nowrap',
   },
   fileInputHidden: {
     display: 'none',
   },
   button: {
-    padding: '8px 14px',
+    padding: '6px 12px',
     background: '#fff',
     border: '1px solid #e2e8f0',
     borderRadius: '6px',
@@ -69,9 +98,10 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     color: '#334155',
     transition: 'all 0.15s',
+    whiteSpace: 'nowrap',
   },
   newButton: {
-    padding: '8px 14px',
+    padding: '6px 12px',
     background: '#f1f5f9',
     color: '#334155',
     border: '1px solid #e2e8f0',
@@ -80,6 +110,7 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '13px',
     fontWeight: 500,
     transition: 'all 0.15s',
+    whiteSpace: 'nowrap',
   },
   status: {
     fontSize: '12px',
@@ -88,6 +119,53 @@ const styles: Record<string, React.CSSProperties> = {
     background: '#f1f5f9',
     borderRadius: '4px',
   },
+  // Mobile menu button (...)
+  menuButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '32px',
+    height: '32px',
+    background: 'transparent',
+    border: '1px solid #e2e8f0',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    fontSize: '18px',
+    color: '#334155',
+    lineHeight: 1,
+    marginLeft: 'auto',
+    flexShrink: 0,
+  },
+  // Mobile menu dropdown
+  menuDropdown: {
+    position: 'absolute',
+    top: '100%',
+    right: 0,
+    marginTop: '4px',
+    background: '#fff',
+    border: '1px solid #e2e8f0',
+    borderRadius: '8px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+    padding: '4px',
+    zIndex: 200,
+    minWidth: '150px',
+  },
+  menuItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '8px 12px',
+    fontSize: '13px',
+    fontWeight: 500,
+    color: '#334155',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    border: 'none',
+    background: 'transparent',
+    width: '100%',
+    textAlign: 'left',
+    whiteSpace: 'nowrap',
+  },
   main: {
     flex: 1,
     display: 'flex',
@@ -95,12 +173,124 @@ const styles: Record<string, React.CSSProperties> = {
   },
 };
 
+function useResponsiveLayout() {
+  const calcZoom = () => {
+    const pageWidth = 816 + 48; // 8.5in * 96dpi + padding
+    const vw = window.innerWidth;
+    return vw < pageWidth ? Math.max(0.35, Math.floor((vw / pageWidth) * 20) / 20) : 1.0;
+  };
+
+  const [zoom, setZoom] = useState(calcZoom);
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
+
+  useEffect(() => {
+    const onResize = () => {
+      setZoom(calcZoom());
+      setIsMobile(window.innerWidth <= 768);
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return { zoom, isMobile };
+}
+
+function MobileMenu({
+  onFileSelect,
+  onNew,
+  onSave,
+  status,
+}: {
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNew: () => void;
+  onSave: () => void;
+  status: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} style={{ position: 'absolute', right: '10px' }}>
+      <button style={styles.menuButton} onClick={() => setOpen(!open)} aria-label="Actions menu">
+        ···
+      </button>
+      {open && (
+        <div style={styles.menuDropdown}>
+          <label
+            style={styles.menuItem}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#f1f5f9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+            }}
+          >
+            <input
+              type="file"
+              accept=".docx"
+              onChange={(e) => {
+                onFileSelect(e);
+                setOpen(false);
+              }}
+              style={{ display: 'none' }}
+            />
+            Open DOCX
+          </label>
+          <button
+            style={styles.menuItem}
+            onClick={() => {
+              onNew();
+              setOpen(false);
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#f1f5f9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+            }}
+          >
+            New
+          </button>
+          <button
+            style={styles.menuItem}
+            onClick={() => {
+              onSave();
+              setOpen(false);
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#f1f5f9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'transparent';
+            }}
+          >
+            Save
+          </button>
+          {status && (
+            <div style={{ padding: '6px 12px', fontSize: '12px', color: '#64748b' }}>{status}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function App() {
   const editorRef = useRef<DocxEditorRef>(null);
   const [currentDocument, setCurrentDocument] = useState<Document | null>(null);
   const [documentBuffer, setDocumentBuffer] = useState<ArrayBuffer | null>(null);
   const [fileName, setFileName] = useState<string>('sample.docx');
   const [status, setStatus] = useState<string>('');
+  const { zoom: autoZoom, isMobile } = useResponsiveLayout();
 
   useEffect(() => {
     fetch('/sample.docx')
@@ -179,33 +369,51 @@ export function App() {
 
   return (
     <div style={styles.container}>
-      <header style={styles.header}>
-        <div style={styles.headerLeft}>
-          <GitHubBadge />
-          <ExampleSwitcher current="Vite" />
-        </div>
-        <div style={styles.headerCenter}>
-          {fileName && <span style={styles.fileName}>{fileName}</span>}
-        </div>
-        <div style={styles.headerRight}>
-          <label style={styles.fileInputLabel}>
-            <input
-              type="file"
-              accept=".docx"
-              onChange={handleFileSelect}
-              style={styles.fileInputHidden}
+      {isMobile ? (
+        <header style={styles.mobileHeader}>
+          <div style={styles.mobileHeaderTop}>
+            <GitHubBadge />
+            <ExampleSwitcher current="Vite" />
+          </div>
+          <div style={styles.mobileHeaderFileName}>
+            {fileName && <span style={styles.fileName}>{fileName}</span>}
+            <MobileMenu
+              onFileSelect={handleFileSelect}
+              onNew={handleNewDocument}
+              onSave={handleSave}
+              status={status}
             />
-            Open DOCX
-          </label>
-          <button style={styles.newButton} onClick={handleNewDocument}>
-            New
-          </button>
-          <button style={styles.button} onClick={handleSave}>
-            Save
-          </button>
-          {status && <span style={styles.status}>{status}</span>}
-        </div>
-      </header>
+          </div>
+        </header>
+      ) : (
+        <header style={styles.header}>
+          <div style={styles.headerLeft}>
+            <GitHubBadge />
+            <ExampleSwitcher current="Vite" />
+          </div>
+          <div style={styles.headerCenter}>
+            {fileName && <span style={styles.fileName}>{fileName}</span>}
+          </div>
+          <div style={styles.headerRight}>
+            <label style={styles.fileInputLabel}>
+              <input
+                type="file"
+                accept=".docx"
+                onChange={handleFileSelect}
+                style={styles.fileInputHidden}
+              />
+              Open DOCX
+            </label>
+            <button style={styles.newButton} onClick={handleNewDocument}>
+              New
+            </button>
+            <button style={styles.button} onClick={handleSave}>
+              Save
+            </button>
+            {status && <span style={styles.status}>{status}</span>}
+          </div>
+        </header>
+      )}
 
       <main style={styles.main}>
         <DocxEditor
@@ -216,11 +424,11 @@ export function App() {
           onError={handleError}
           onFontsLoaded={handleFontsLoaded}
           showToolbar={true}
-          showRuler={true}
+          showRuler={!isMobile}
           showVariablePanel={true}
           showZoomControl={true}
           showPageNumbers={false}
-          initialZoom={1.0}
+          initialZoom={autoZoom}
           variablePanelPosition="right"
         />
       </main>

--- a/examples/vite/src/styles.css
+++ b/examples/vite/src/styles.css
@@ -5,3 +5,21 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Mobile responsive overrides */
+@media (max-width: 768px) {
+  /* Compact toolbar on mobile - horizontal scroll instead of wrapping */
+  .ep-root [role='toolbar'] {
+    padding: 4px 4px;
+    gap: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    flex-wrap: nowrap !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    min-height: 36px;
+  }
+  .ep-root [role='toolbar']::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/src/components/DocxEditorHelpers.tsx
+++ b/src/components/DocxEditorHelpers.tsx
@@ -24,28 +24,28 @@ export function DefaultLoadingIndicator(): React.ReactElement {
         alignItems: 'center',
         justifyContent: 'center',
         height: '100%',
+        gap: '20px',
         color: 'var(--doc-text-muted)',
       }}
     >
       <div
         style={{
-          width: '40px',
-          height: '40px',
+          width: '36px',
+          height: '36px',
           border: '3px solid var(--doc-border)',
-          borderTop: '3px solid var(--doc-primary)',
+          borderTopColor: 'var(--doc-primary)',
           borderRadius: '50%',
-          animation: 'docx-spin 1s linear infinite',
+          animation: 'docx-spin 0.8s linear infinite',
         }}
       />
       <style>
         {`
           @keyframes docx-spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
+            to { transform: rotate(360deg); }
           }
         `}
       </style>
-      <div style={{ marginTop: '16px' }}>Loading document...</div>
+      <div style={{ fontSize: '14px' }}>Loading document...</div>
     </div>
   );
 }


### PR DESCRIPTION
- Add responsive header with stacked layout on mobile (brand row + filename row with action menu)
- Auto-fit zoom based on viewport width so pages fit mobile screens
- Horizontally scrollable toolbar on mobile instead of wrapping
- Hide ruler on mobile for more content space
- Replace plain "Loading DOCX Editor..." text with animated spinner
- Improve DefaultLoadingIndicator component styling