### PR TITLE
feat: page break support + File/Insert menu bar

### DIFF
--- a/src/components/DocxEditor.tsx
+++ b/src/components/DocxEditor.tsx
@@ -114,6 +114,8 @@ import {
   setHyperlink,
   removeHyperlink,
   insertHyperlink,
+  // Page break command
+  insertPageBreak,
   // Table commands
   getTableContext,
   insertTable,
@@ -745,6 +747,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     },
     [getActiveEditorView, focusActiveEditor]
   );
+
+  // Insert a page break at cursor
+  const handleInsertPageBreak = useCallback(() => {
+    const view = getActiveEditorView();
+    if (!view) return;
+    insertPageBreak(view.state, view.dispatch);
+    focusActiveEditor();
+  }, [getActiveEditorView, focusActiveEditor]);
 
   // Trigger file picker for image insert
   const handleInsertImageClick = useCallback(() => {
@@ -2032,6 +2042,7 @@ body { background: white; }
                     onInsertTable={handleInsertTable}
                     showTableInsert={true}
                     onInsertImage={handleInsertImageClick}
+                    onInsertPageBreak={handleInsertPageBreak}
                     imageContext={state.pmImageContext}
                     onImageWrapType={handleImageWrapType}
                     onImageTransform={handleImageTransform}

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -671,6 +671,14 @@ export function IconMoreVert(props: IconProps) {
   );
 }
 
+export function IconPageBreak(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M120-440v-80h160v80H120Zm200 0v-80h160v80H320Zm200 0v-80h160v80H520Zm200 0v-80h120v80H720ZM240-120q-33 0-56.5-23.5T160-200v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-120H240Zm-80-520v-120q0-33 23.5-56.5T240-840h480q33 0 56.5 23.5T800-760v120h-80v-120H240v120h-80Z" />
+    </SvgIcon>
+  );
+}
+
 // ============================================================================
 // ICON MAP - for MaterialSymbol compatibility
 // ============================================================================
@@ -757,6 +765,8 @@ const iconMap: Record<string, React.ComponentType<IconProps>> = {
   keyboard_arrow_left: IconKeyboardArrowLeft,
   keyboard_arrow_right: IconKeyboardArrowRight,
   more_vert: IconMoreVert,
+  // Page break
+  page_break: IconPageBreak,
 };
 
 /**

--- a/src/components/ui/MenuDropdown.tsx
+++ b/src/components/ui/MenuDropdown.tsx
@@ -1,0 +1,234 @@
+/**
+ * MenuDropdown — a reusable dropdown menu with text label trigger
+ *
+ * Supports submenu panels that appear to the right on hover (Google Docs style).
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { MaterialSymbol } from './MaterialSymbol';
+
+export interface MenuItem {
+  icon?: string;
+  label: string;
+  shortcut?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  /** Custom content to render instead of a simple menu item */
+  customContent?: ReactNode;
+  /** Submenu content that appears to the right on hover */
+  submenuContent?: (closeMenu: () => void) => ReactNode;
+}
+
+export interface MenuSeparator {
+  type: 'separator';
+}
+
+export type MenuEntry = MenuItem | MenuSeparator;
+
+function isSeparator(entry: MenuEntry): entry is MenuSeparator {
+  return 'type' in entry && entry.type === 'separator';
+}
+
+interface MenuDropdownProps {
+  label: string;
+  items: MenuEntry[];
+  disabled?: boolean;
+}
+
+const triggerStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  padding: '2px 8px',
+  border: 'none',
+  background: 'transparent',
+  borderRadius: 4,
+  cursor: 'pointer',
+  fontSize: 13,
+  fontWeight: 400,
+  color: 'var(--doc-text, #374151)',
+  whiteSpace: 'nowrap',
+  height: 28,
+  lineHeight: '28px',
+};
+
+const triggerOpenStyle: CSSProperties = {
+  ...triggerStyle,
+  background: 'var(--doc-hover, #f3f4f6)',
+};
+
+const dropdownStyle: CSSProperties = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  marginTop: 2,
+  backgroundColor: 'white',
+  border: '1px solid var(--doc-border, #d1d5db)',
+  borderRadius: 6,
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.12)',
+  padding: '4px 0',
+  zIndex: 1000,
+  minWidth: 200,
+};
+
+const menuItemStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 12px',
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  fontSize: 13,
+  color: 'var(--doc-text, #374151)',
+  width: '100%',
+  textAlign: 'left',
+  whiteSpace: 'nowrap',
+};
+
+const menuItemDisabledStyle: CSSProperties = {
+  ...menuItemStyle,
+  opacity: 0.4,
+  cursor: 'default',
+};
+
+const separatorStyle: CSSProperties = {
+  height: 1,
+  backgroundColor: 'var(--doc-border, #e5e7eb)',
+  margin: '4px 0',
+};
+
+const shortcutStyle: CSSProperties = {
+  marginLeft: 'auto',
+  fontSize: 12,
+  color: 'var(--doc-text-muted, #9ca3af)',
+};
+
+const submenuPanelStyle: CSSProperties = {
+  position: 'absolute',
+  left: '100%',
+  top: -4,
+  marginLeft: 2,
+  backgroundColor: 'white',
+  border: '1px solid var(--doc-border, #d1d5db)',
+  borderRadius: 6,
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.12)',
+  padding: 8,
+  zIndex: 1001,
+};
+
+export function MenuDropdown({ label, items, disabled }: MenuDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hoveredSubmenu, setHoveredSubmenu] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+    setHoveredSubmenu(null);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        closeMenu();
+      }
+    }
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') closeMenu();
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, closeMenu]);
+
+  const handleItemClick = (item: MenuItem) => {
+    if (item.disabled || item.submenuContent) return;
+    if (!item.onClick) return;
+    item.onClick();
+    closeMenu();
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onMouseDown={(e) => e.preventDefault()}
+        disabled={disabled}
+        style={isOpen ? triggerOpenStyle : triggerStyle}
+      >
+        {label}
+        <MaterialSymbol name="arrow_drop_down" size={16} />
+      </button>
+
+      {isOpen && (
+        <div style={dropdownStyle}>
+          {items.map((entry, i) => {
+            if (isSeparator(entry)) {
+              return <div key={`sep-${i}`} style={separatorStyle} />;
+            }
+            const item = entry;
+            if (item.customContent) {
+              return (
+                <div key={item.label} onMouseDown={(e) => e.preventDefault()}>
+                  {item.customContent}
+                </div>
+              );
+            }
+
+            const hasSubmenu = !!item.submenuContent;
+            const isSubmenuOpen = hoveredSubmenu === item.label;
+
+            return (
+              <div
+                key={item.label}
+                style={{ position: 'relative' }}
+                onMouseEnter={() => hasSubmenu && setHoveredSubmenu(item.label)}
+                onMouseLeave={() => hasSubmenu && setHoveredSubmenu(null)}
+              >
+                <button
+                  type="button"
+                  style={item.disabled ? menuItemDisabledStyle : menuItemStyle}
+                  onClick={() => handleItemClick(item)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseOver={(e) => {
+                    if (!item.disabled) {
+                      (e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                        'var(--doc-hover, #f3f4f6)';
+                    }
+                  }}
+                  onMouseOut={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.backgroundColor = 'transparent';
+                  }}
+                  disabled={item.disabled}
+                >
+                  {item.icon && <MaterialSymbol name={item.icon} size={18} />}
+                  <span>{item.label}</span>
+                  {item.shortcut && <span style={shortcutStyle}>{item.shortcut}</span>}
+                  {hasSubmenu && (
+                    <span style={{ marginLeft: 'auto' }}>
+                      <MaterialSymbol name="keyboard_arrow_right" size={16} />
+                    </span>
+                  )}
+                </button>
+                {hasSubmenu && isSubmenuOpen && (
+                  <div style={submenuPanelStyle} onMouseDown={(e) => e.preventDefault()}>
+                    {item.submenuContent!(closeMenu)}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/TableGridInline.tsx
+++ b/src/components/ui/TableGridInline.tsx
@@ -1,0 +1,94 @@
+/**
+ * TableGridInline — a grid picker for table dimensions, rendered inline (no button/dropdown wrapper).
+ * Used both standalone inside menu submenus and internally by TableGridPicker.
+ */
+
+import { useState, useCallback } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+
+interface TableGridInlineProps {
+  onInsert: (rows: number, columns: number) => void;
+  gridRows?: number;
+  gridColumns?: number;
+}
+
+const CELL_SIZE = 18;
+const CELL_GAP = 2;
+
+const cellStyle: CSSProperties = {
+  width: CELL_SIZE,
+  height: CELL_SIZE,
+  backgroundColor: 'white',
+  border: '1px solid var(--doc-border, #d1d5db)',
+  borderRadius: 2,
+  transition: 'background-color 0.1s, border-color 0.1s',
+  cursor: 'pointer',
+};
+
+const cellSelectedStyle: CSSProperties = {
+  ...cellStyle,
+  backgroundColor: 'var(--doc-primary, #3b82f6)',
+  border: '1px solid var(--doc-primary, #3b82f6)',
+};
+
+const labelStyle: CSSProperties = {
+  marginTop: 6,
+  fontSize: 11,
+  fontWeight: 500,
+  color: 'var(--doc-text, #374151)',
+  textAlign: 'center',
+};
+
+export function TableGridInline({ onInsert, gridRows = 6, gridColumns = 6 }: TableGridInlineProps) {
+  const [hoverRows, setHoverRows] = useState(0);
+  const [hoverCols, setHoverCols] = useState(0);
+
+  const handleCellClick = useCallback(() => {
+    if (hoverRows > 0 && hoverCols > 0) {
+      onInsert(hoverRows, hoverCols);
+    }
+  }, [hoverRows, hoverCols, onInsert]);
+
+  const gridCells: ReactElement[] = [];
+  for (let row = 1; row <= gridRows; row++) {
+    for (let col = 1; col <= gridColumns; col++) {
+      const isSelected = row <= hoverRows && col <= hoverCols;
+      gridCells.push(
+        <div
+          key={`${row}-${col}`}
+          style={isSelected ? cellSelectedStyle : cellStyle}
+          onMouseEnter={() => {
+            setHoverRows(row);
+            setHoverCols(col);
+          }}
+          onClick={handleCellClick}
+          role="gridcell"
+          aria-selected={isSelected}
+        />
+      );
+    }
+  }
+
+  const gridLabel = hoverRows > 0 && hoverCols > 0 ? `${hoverCols} × ${hoverRows}` : 'Select size';
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'grid',
+          gap: CELL_GAP,
+          gridTemplateColumns: `repeat(${gridColumns}, ${CELL_SIZE}px)`,
+        }}
+        onMouseLeave={() => {
+          setHoverRows(0);
+          setHoverCols(0);
+        }}
+        role="grid"
+        aria-label="Table size selector"
+      >
+        {gridCells}
+      </div>
+      <div style={labelStyle}>{gridLabel}</div>
+    </div>
+  );
+}

--- a/src/layout-bridge/toFlowBlocks.ts
+++ b/src/layout-bridge/toFlowBlocks.ts
@@ -896,16 +896,17 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
         break;
 
       case 'horizontalRule':
-        // Could be treated as a page break or separator
-        const pageBreak: PageBreakBlock = {
+      case 'pageBreak': {
+        const pb: PageBreakBlock = {
           kind: 'pageBreak',
           id: nextBlockId(),
           pmStart: pos,
           pmEnd: pos + node.nodeSize,
         };
-        blocks.push(pageBreak);
+        blocks.push(pb);
         listCounters.clear();
         break;
+      }
     }
   });
 

--- a/src/prosemirror/commands/index.ts
+++ b/src/prosemirror/commands/index.ts
@@ -102,3 +102,6 @@ export {
   setTableBorderWidth,
 } from './table';
 export type { TableContextInfo, BorderPreset } from './table';
+
+// Page break
+export { insertPageBreak } from './pageBreak';

--- a/src/prosemirror/commands/pageBreak.ts
+++ b/src/prosemirror/commands/pageBreak.ts
@@ -1,0 +1,56 @@
+/**
+ * Page Break Commands
+ */
+
+import type { Command } from 'prosemirror-state';
+import { TextSelection } from 'prosemirror-state';
+import { Fragment } from 'prosemirror-model';
+
+/**
+ * Insert a page break at the current cursor position.
+ * Always ensures a paragraph follows the page break and places the cursor there.
+ */
+export const insertPageBreak: Command = (state, dispatch) => {
+  const { schema } = state;
+  const pageBreakType = schema.nodes.pageBreak;
+  const paragraphType = schema.nodes.paragraph;
+  if (!pageBreakType || !paragraphType) return false;
+
+  if (dispatch) {
+    const { $from } = state.selection;
+    const tr = state.tr;
+    const pbNode = pageBreakType.create();
+    const pbSize = pbNode.nodeSize;
+    let cursorPos: number;
+
+    if ($from.parent.isTextblock) {
+      if ($from.parentOffset > 0 && $from.parentOffset < $from.parent.content.size) {
+        // Mid-text: split paragraph, then insert pageBreak + empty paragraph between them
+        tr.split($from.pos);
+        const mappedPos = tr.mapping.map($from.pos);
+        tr.insert(mappedPos, Fragment.from([pbNode, paragraphType.create()]));
+        cursorPos = mappedPos + pbSize + 1;
+      } else if ($from.parentOffset === $from.parent.content.size) {
+        // End of text block: insert pageBreak + empty paragraph after this block
+        const after = $from.after();
+        tr.insert(after, Fragment.from([pbNode, paragraphType.create()]));
+        cursorPos = after + pbSize + 1;
+      } else {
+        // Start of text block: insert pageBreak before, current block remains after
+        const before = $from.before();
+        tr.insert(before, pbNode);
+        cursorPos = before + pbSize + 1;
+      }
+    } else {
+      // Not in a textblock — insert pageBreak + empty paragraph at current position
+      const pos = $from.pos;
+      tr.insert(pos, Fragment.from([pbNode, paragraphType.create()]));
+      cursorPos = pos + pbSize + 1;
+    }
+
+    tr.setSelection(TextSelection.create(tr.doc, cursorPos));
+    dispatch(tr.scrollIntoView());
+  }
+
+  return true;
+};

--- a/src/prosemirror/conversion/fromProseDoc.ts
+++ b/src/prosemirror/conversion/fromProseDoc.ts
@@ -98,10 +98,25 @@ function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
     } else if (node.type.name === 'textBox') {
       // Convert text box back to a paragraph containing a shape with text body
       blocks.push(convertPMTextBox(node));
+    } else if (node.type.name === 'pageBreak') {
+      // Convert page break node to a paragraph with a page break run
+      blocks.push(createPageBreakParagraph());
     }
   });
 
   return blocks;
+}
+
+/**
+ * Create a paragraph containing only a page break run (for DOCX serialization)
+ */
+function createPageBreakParagraph(): Paragraph {
+  const breakContent: BreakContent = { type: 'break', breakType: 'page' };
+  const run: Run = { type: 'run', content: [breakContent] };
+  return {
+    type: 'paragraph',
+    content: [run],
+  };
 }
 
 /**

--- a/src/prosemirror/conversion/toProseDoc.ts
+++ b/src/prosemirror/conversion/toProseDoc.ts
@@ -74,6 +74,10 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
       for (const tb of textBoxes) {
         nodes.push(convertTextBox(tb, styleResolver));
       }
+      // If any run in this paragraph contains a page break, emit a pageBreak node after
+      if (paragraphHasPageBreak(block)) {
+        nodes.push(schema.node('pageBreak'));
+      }
     } else if (block.type === 'table') {
       const pmTable = convertTable(block, styleResolver);
       nodes.push(pmTable);
@@ -1702,6 +1706,22 @@ export function headerFooterToProseDoc(
   }
 
   return schema.node('doc', null, nodes);
+}
+
+/**
+ * Check if a paragraph contains a page break in any of its runs
+ */
+function paragraphHasPageBreak(paragraph: Paragraph): boolean {
+  for (const item of paragraph.content) {
+    if (item.type === 'run') {
+      for (const content of (item as Run).content) {
+        if (content.type === 'break' && content.breakType === 'page') {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/prosemirror/extensions/StarterKit.ts
+++ b/src/prosemirror/extensions/StarterKit.ts
@@ -50,6 +50,7 @@ import { ImageExtension } from './nodes/ImageExtension';
 import { TextBoxExtension } from './nodes/TextBoxExtension';
 import { ShapeExtension } from './nodes/ShapeExtension';
 import { HorizontalRuleExtension } from './nodes/HorizontalRuleExtension';
+import { PageBreakExtension } from './nodes/PageBreakExtension';
 import { FieldExtension } from './nodes/FieldExtension';
 import { SdtExtension } from './nodes/SdtExtension';
 import { MathExtension } from './nodes/MathExtension';
@@ -133,6 +134,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   add('imageDrag', ImageDragExtension());
   add('dropCursor', DropCursorExtension());
   add('horizontalRule', HorizontalRuleExtension());
+  add('pageBreak', PageBreakExtension());
   add('field', FieldExtension());
   add('sdt', SdtExtension());
   add('math', MathExtension());

--- a/src/prosemirror/extensions/core/DocExtension.ts
+++ b/src/prosemirror/extensions/core/DocExtension.ts
@@ -8,6 +8,6 @@ export const DocExtension = createNodeExtension({
   name: 'doc',
   schemaNodeName: 'doc',
   nodeSpec: {
-    content: '(paragraph | horizontalRule | table)+',
+    content: '(paragraph | horizontalRule | pageBreak | table)+',
   },
 });

--- a/src/prosemirror/extensions/nodes/PageBreakExtension.ts
+++ b/src/prosemirror/extensions/nodes/PageBreakExtension.ts
@@ -1,0 +1,19 @@
+/**
+ * Page Break Extension — block node representing a DOCX page break
+ */
+
+import { createNodeExtension } from '../create';
+
+export const PageBreakExtension = createNodeExtension({
+  name: 'pageBreak',
+  schemaNodeName: 'pageBreak',
+  nodeSpec: {
+    group: 'block',
+    atom: true,
+    selectable: true,
+    parseDOM: [{ tag: 'div.docx-page-break' }],
+    toDOM() {
+      return ['div', { class: 'docx-page-break' }];
+    },
+  },
+});

--- a/src/prosemirror/index.ts
+++ b/src/prosemirror/index.ts
@@ -128,5 +128,7 @@ export {
   setCellFillColor,
   setTableBorderColor,
   setTableBorderWidth,
+  // Page break
+  insertPageBreak,
 } from './commands';
 export type { TableContextInfo, BorderPreset } from './commands';


### PR DESCRIPTION
## Summary

- Adds full **page break** support: import from DOCX, insert via menu, export back to DOCX, layout engine page splitting
- Adds Google Docs-style **File** and **Insert** dropdown menus to the toolbar, replacing scattered icon buttons
- Insert > Table now shows a grid picker submenu for choosing dimensions
- Refactors `TableGridPicker` to share grid logic via new `TableGridInline` component (DRY)

## Changes

### Page Break Node (ProseMirror + Layout)
- `PageBreakExtension` — new atom block node registered in schema
- `toProseDoc.ts` — detects DOCX page break runs → emits `pageBreak` PM nodes
- `fromProseDoc.ts` — converts `pageBreak` PM nodes → DOCX paragraphs with break content
- `toFlowBlocks.ts` — maps `pageBreak` to `PageBreakBlock` (layout engine handles page splitting)
- `insertPageBreak` command — splits paragraphs, inserts break + empty paragraph, places cursor on next page

### Menu Bar
- `MenuDropdown` — reusable dropdown with submenu support (hover to expand)
- `TableGridInline` — extracted grid component shared by `TableGridPicker` and menu submenu
- `IconPageBreak` — new SVG icon added to icon system
- Toolbar updated: File menu (Print), Insert menu (Image, Table with grid picker, Page break)

## Test plan

- [x] Open a DOCX file with page breaks → verify pages split correctly
- [x] Use Insert > Page break → verify new page starts, cursor on next page
- [x] Round-trip: open DOCX with page breaks → save → reopen → breaks preserved
- [x] Insert > Table submenu → grid picker appears on hover, selecting inserts table
- [x] File > Print works
- [x] Insert > Image triggers file picker

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)