### PR TITLE
feat: simplify image toolbar, add selection/drag, fix OOXML round-trip

### DIFF
--- a/src/components/DocxEditor.tsx
+++ b/src/components/DocxEditor.tsx
@@ -923,11 +923,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [getActiveEditorView, focusActiveEditor, state.pmImageContext]
   );
 
-  // Open image position dialog
-  const handleOpenImagePosition = useCallback(() => {
-    setImagePositionOpen(true);
-  }, []);
-
   // Apply image position changes
   const handleApplyImagePosition = useCallback(
     (data: ImagePositionData) => {
@@ -2046,7 +2041,6 @@ body { background: white; }
                     imageContext={state.pmImageContext}
                     onImageWrapType={handleImageWrapType}
                     onImageTransform={handleImageTransform}
-                    onOpenImagePosition={handleOpenImagePosition}
                     onOpenImageProperties={handleOpenImageProperties}
                     tableContext={state.pmTableContext}
                     onTableAction={handleTableAction}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -31,6 +31,8 @@ import { TableCellFillPicker } from './ui/TableCellFillPicker';
 import { TableMoreDropdown } from './ui/TableMoreDropdown';
 import { MenuDropdown } from './ui/MenuDropdown';
 import type { MenuEntry } from './ui/MenuDropdown';
+import { ImageWrapDropdown } from './ui/ImageWrapDropdown';
+import { ImageTransformDropdown } from './ui/ImageTransformDropdown';
 import type { TableAction } from './ui/TableToolbar';
 import { cn } from '../lib/utils';
 
@@ -186,8 +188,6 @@ export interface ToolbarProps {
   onImageWrapType?: (wrapType: string) => void;
   /** Callback for image transform (rotate/flip) */
   onImageTransform?: (action: 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV') => void;
-  /** Callback to open image position dialog */
-  onOpenImagePosition?: () => void;
   /** Callback to open image properties dialog (alt text + border) */
   onOpenImageProperties?: () => void;
   /** Table context when cursor is in a table */
@@ -372,7 +372,6 @@ export function Toolbar({
   imageContext,
   onImageWrapType,
   onImageTransform,
-  onOpenImagePosition,
   onOpenImageProperties,
   tableContext,
   onTableAction,
@@ -942,72 +941,16 @@ export function Toolbar({
         </ToolbarGroup>
       )}
 
-      {/* Image Wrapping - shown when image is selected */}
+      {/* Image controls - shown when image is selected */}
       {imageContext && onImageWrapType && (
         <ToolbarGroup label="Image">
-          <ToolbarButton
-            active={imageContext.wrapType === 'inline'}
-            onClick={() => onImageWrapType('inline')}
+          <ImageWrapDropdown
+            imageContext={imageContext}
+            onChange={onImageWrapType}
             disabled={disabled}
-            title="Inline with text"
-            ariaLabel="Inline with text"
-          >
-            <MaterialSymbol name="format_image_left" size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            active={imageContext.displayMode === 'float' && imageContext.cssFloat === 'left'}
-            onClick={() => onImageWrapType('wrapRight')}
-            disabled={disabled}
-            title="Wrap text (float left)"
-            ariaLabel="Float left"
-          >
-            <MaterialSymbol name="format_image_right" size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            active={imageContext.displayMode === 'float' && imageContext.cssFloat === 'right'}
-            onClick={() => onImageWrapType('wrapLeft')}
-            disabled={disabled}
-            title="Wrap text (float right)"
-            ariaLabel="Float right"
-          >
-            <MaterialSymbol name="format_image_left" size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            active={imageContext.wrapType === 'topAndBottom'}
-            onClick={() => onImageWrapType('topAndBottom')}
-            disabled={disabled}
-            title="Top and bottom"
-            ariaLabel="Top and bottom"
-          >
-            <MaterialSymbol name="horizontal_rule" size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            active={imageContext.wrapType === 'behind'}
-            onClick={() => onImageWrapType('behind')}
-            disabled={disabled}
-            title="Behind text"
-            ariaLabel="Behind text"
-          >
-            <MaterialSymbol name="flip_to_back" size={ICON_SIZE} />
-          </ToolbarButton>
-          <ToolbarButton
-            active={imageContext.wrapType === 'inFront'}
-            onClick={() => onImageWrapType('inFront')}
-            disabled={disabled}
-            title="In front of text"
-            ariaLabel="In front of text"
-          >
-            <MaterialSymbol name="flip_to_front" size={ICON_SIZE} />
-          </ToolbarButton>
-          {onOpenImagePosition && (
-            <ToolbarButton
-              onClick={onOpenImagePosition}
-              disabled={disabled}
-              title="Image position..."
-              ariaLabel="Image position"
-            >
-              <MaterialSymbol name="open_with" size={ICON_SIZE} />
-            </ToolbarButton>
+          />
+          {onImageTransform && (
+            <ImageTransformDropdown onTransform={onImageTransform} disabled={disabled} />
           )}
           {onOpenImageProperties && (
             <ToolbarButton
@@ -1018,42 +961,6 @@ export function Toolbar({
             >
               <MaterialSymbol name="tune" size={ICON_SIZE} />
             </ToolbarButton>
-          )}
-          {onImageTransform && (
-            <>
-              <ToolbarButton
-                onClick={() => onImageTransform('rotateCW')}
-                disabled={disabled}
-                title="Rotate clockwise"
-                ariaLabel="Rotate clockwise"
-              >
-                <MaterialSymbol name="rotate_right" size={ICON_SIZE} />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => onImageTransform('rotateCCW')}
-                disabled={disabled}
-                title="Rotate counter-clockwise"
-                ariaLabel="Rotate counter-clockwise"
-              >
-                <MaterialSymbol name="rotate_left" size={ICON_SIZE} />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => onImageTransform('flipH')}
-                disabled={disabled}
-                title="Flip horizontal"
-                ariaLabel="Flip horizontal"
-              >
-                <MaterialSymbol name="swap_horiz" size={ICON_SIZE} />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => onImageTransform('flipV')}
-                disabled={disabled}
-                title="Flip vertical"
-                ariaLabel="Flip vertical"
-              >
-                <MaterialSymbol name="swap_vert" size={ICON_SIZE} />
-              </ToolbarButton>
-            </>
           )}
         </ToolbarGroup>
       )}

--- a/src/components/ui/IconGridDropdown.tsx
+++ b/src/components/ui/IconGridDropdown.tsx
@@ -1,0 +1,173 @@
+/**
+ * Shared icon-grid dropdown used by image toolbar controls.
+ *
+ * Renders a trigger button (icon + chevron) that opens a floating
+ * row of icon buttons. Handles click-outside, Escape, focus-stealing
+ * prevention, and optional active-state highlighting.
+ */
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { MaterialSymbol } from './MaterialSymbol';
+import { Button } from './Button';
+import { Tooltip } from './Tooltip';
+import { cn } from '../../lib/utils';
+
+const ICON_SIZE = 20;
+
+export interface IconGridOption<T extends string = string> {
+  value: T;
+  label: string;
+  iconName: string;
+}
+
+export interface IconGridDropdownProps<T extends string = string> {
+  /** Options to display in the grid */
+  options: IconGridOption<T>[];
+  /** Currently active value (highlighted in the grid), or null */
+  activeValue?: T | null;
+  /** Icon shown on the trigger button */
+  triggerIcon: string;
+  /** Tooltip text when closed */
+  tooltipContent: string;
+  /** Fired when an option is clicked */
+  onSelect: (value: T) => void;
+  disabled?: boolean;
+  /** aria-label for the trigger button */
+  ariaLabel?: string;
+  /** data-testid for the trigger button */
+  testId?: string;
+}
+
+export function IconGridDropdown<T extends string = string>({
+  options,
+  activeValue,
+  triggerIcon,
+  tooltipContent,
+  onSelect,
+  disabled = false,
+  ariaLabel,
+  testId,
+}: IconGridDropdownProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on click-outside and Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const onEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    document.addEventListener('keydown', onEscape);
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onEscape);
+    };
+  }, [isOpen]);
+
+  // Prevent focus stealing from ProseMirror
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleOptionClick = useCallback(
+    (value: T) => {
+      if (!disabled) onSelect(value);
+      setIsOpen(false);
+    },
+    [disabled, onSelect]
+  );
+
+  const triggerButton = (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className={cn(
+        'text-slate-500 hover:text-slate-900 hover:bg-slate-100/80',
+        isOpen && 'bg-slate-100',
+        disabled && 'opacity-30 cursor-not-allowed'
+      )}
+      onMouseDown={handleMouseDown}
+      onClick={() => !disabled && setIsOpen((prev) => !prev)}
+      disabled={disabled}
+      aria-label={ariaLabel ?? tooltipContent}
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      data-testid={testId}
+    >
+      <MaterialSymbol name={triggerIcon} size={ICON_SIZE} />
+      <MaterialSymbol name="arrow_drop_down" size={14} className="-ml-1" />
+    </Button>
+  );
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', display: 'inline-block' }}>
+      {!isOpen ? <Tooltip content={tooltipContent}>{triggerButton}</Tooltip> : triggerButton}
+
+      {isOpen && !disabled && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            marginTop: 4,
+            backgroundColor: 'white',
+            border: '1px solid var(--doc-border)',
+            borderRadius: 8,
+            boxShadow: '0 4px 16px rgba(0, 0, 0, 0.12)',
+            padding: 6,
+            zIndex: 1000,
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div style={{ display: 'flex', gap: 2 }}>
+            {options.map((option) => {
+              const isActive = activeValue === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  title={option.label}
+                  data-testid={testId ? `${testId}-${option.value}` : undefined}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 32,
+                    height: 32,
+                    border: '1px solid transparent',
+                    borderRadius: 4,
+                    backgroundColor: isActive ? 'var(--doc-primary-light)' : 'transparent',
+                    cursor: 'pointer',
+                    color: isActive ? 'var(--doc-primary)' : 'var(--doc-text)',
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={(e) => {
+                    if (!isActive) {
+                      (e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                        'var(--doc-bg-hover)';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.backgroundColor = isActive
+                      ? 'var(--doc-primary-light)'
+                      : 'transparent';
+                  }}
+                  onClick={() => handleOptionClick(option.value)}
+                >
+                  <MaterialSymbol name={option.iconName} size={18} />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ImageTransformDropdown.tsx
+++ b/src/components/ui/ImageTransformDropdown.tsx
@@ -1,0 +1,35 @@
+/**
+ * Image Transform Dropdown — thin wrapper around IconGridDropdown.
+ */
+
+import { IconGridDropdown, type IconGridOption } from './IconGridDropdown';
+
+type TransformAction = 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
+
+const TRANSFORM_OPTIONS: IconGridOption<TransformAction>[] = [
+  { value: 'rotateCW', label: 'Rotate clockwise', iconName: 'rotate_right' },
+  { value: 'rotateCCW', label: 'Rotate counter-clockwise', iconName: 'rotate_left' },
+  { value: 'flipH', label: 'Flip horizontal', iconName: 'swap_horiz' },
+  { value: 'flipV', label: 'Flip vertical', iconName: 'swap_vert' },
+];
+
+export interface ImageTransformDropdownProps {
+  onTransform: (action: TransformAction) => void;
+  disabled?: boolean;
+}
+
+export function ImageTransformDropdown({
+  onTransform,
+  disabled = false,
+}: ImageTransformDropdownProps) {
+  return (
+    <IconGridDropdown<TransformAction>
+      options={TRANSFORM_OPTIONS}
+      triggerIcon="rotate_right"
+      tooltipContent="Transform"
+      onSelect={onTransform}
+      disabled={disabled}
+      testId="toolbar-image-transform"
+    />
+  );
+}

--- a/src/components/ui/ImageWrapDropdown.tsx
+++ b/src/components/ui/ImageWrapDropdown.tsx
@@ -1,0 +1,51 @@
+/**
+ * Image Wrap Dropdown — thin wrapper around IconGridDropdown.
+ */
+
+import { IconGridDropdown, type IconGridOption } from './IconGridDropdown';
+
+const WRAP_OPTIONS: IconGridOption[] = [
+  { value: 'inline', label: 'Inline with text', iconName: 'format_image_left' },
+  { value: 'wrapRight', label: 'Float left (wrap right)', iconName: 'format_image_right' },
+  { value: 'wrapLeft', label: 'Float right (wrap left)', iconName: 'format_image_left' },
+  { value: 'topAndBottom', label: 'Top and bottom', iconName: 'horizontal_rule' },
+  { value: 'behind', label: 'Behind text', iconName: 'flip_to_back' },
+  { value: 'inFront', label: 'In front of text', iconName: 'flip_to_front' },
+];
+
+export interface ImageWrapDropdownProps {
+  imageContext: {
+    wrapType: string;
+    displayMode: string;
+    cssFloat: string | null;
+  };
+  onChange: (wrapType: string) => void;
+  disabled?: boolean;
+}
+
+function getActiveWrapValue(ctx: ImageWrapDropdownProps['imageContext']): string {
+  if (ctx.displayMode === 'float' && ctx.cssFloat === 'left') return 'wrapRight';
+  if (ctx.displayMode === 'float' && ctx.cssFloat === 'right') return 'wrapLeft';
+  return ctx.wrapType;
+}
+
+export function ImageWrapDropdown({
+  imageContext,
+  onChange,
+  disabled = false,
+}: ImageWrapDropdownProps) {
+  const activeValue = getActiveWrapValue(imageContext);
+  const currentOption = WRAP_OPTIONS.find((o) => o.value === activeValue) || WRAP_OPTIONS[0];
+
+  return (
+    <IconGridDropdown
+      options={WRAP_OPTIONS}
+      activeValue={activeValue}
+      triggerIcon={currentOption.iconName}
+      tooltipContent={`Wrap: ${currentOption.label}`}
+      onSelect={onChange}
+      disabled={disabled}
+      testId="toolbar-image-wrap"
+    />
+  );
+}

--- a/src/layout-painter/renderPage.ts
+++ b/src/layout-painter/renderPage.ts
@@ -51,6 +51,10 @@ interface PageFloatingImage {
   distBottom: number;
   distLeft: number;
   distRight: number;
+  /** ProseMirror start position for click-to-select */
+  pmStart?: number;
+  /** ProseMirror end position */
+  pmEnd?: number;
 }
 
 /**
@@ -362,6 +366,8 @@ function extractFloatingImagesFromParagraph(
       distBottom,
       distLeft,
       distRight,
+      pmStart: imgRun.pmStart,
+      pmEnd: imgRun.pmEnd,
     });
   }
 
@@ -437,6 +443,8 @@ function renderFloatingImagesLayer(
     container.style.pointerEvents = 'auto'; // Make images clickable
     container.style.top = `${floatImg.y}px`;
     container.style.left = `${floatImg.x}px`;
+    if (floatImg.pmStart !== undefined) container.dataset.pmStart = String(floatImg.pmStart);
+    if (floatImg.pmEnd !== undefined) container.dataset.pmEnd = String(floatImg.pmEnd);
 
     const img = doc.createElement('img');
     img.src = floatImg.src;

--- a/src/layout-painter/renderParagraph.ts
+++ b/src/layout-painter/renderParagraph.ts
@@ -785,10 +785,9 @@ export function renderParagraphFragment(
     fragmentEl.dataset.continuesOnNext = 'true';
   }
 
-  // NOTE: Floating image exclusion zones (options.floatingImageInfo) and
-  // fragment Y position (options.fragmentContentY) are accepted but not used.
-  // Text wrapping around floating images is not yet implemented at measurement time.
-  // Floating images skip during inline rendering - they're rendered at page level.
+  // Text wrapping around floating images is handled at measurement time via
+  // per-line leftOffset/rightOffset in MeasuredLine. Floating images themselves
+  // skip inline rendering - they're rendered at page level.
   for (const run of block.runs) {
     if (isImageRun(run)) {
       const isFloating =

--- a/src/paged-editor/ImageSelectionOverlay.tsx
+++ b/src/paged-editor/ImageSelectionOverlay.tsx
@@ -1,0 +1,504 @@
+/**
+ * ImageSelectionOverlay Component
+ *
+ * Renders a selection overlay with resize handles over a selected image
+ * in the visible pages. Handles:
+ * - Blue selection border
+ * - 4 corner resize handles
+ * - Drag-to-resize with aspect ratio lock
+ * - Dimension tooltip during resize
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import type { CSSProperties } from 'react';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type ResizeHandle = 'nw' | 'ne' | 'se' | 'sw';
+
+export interface ImageSelectionInfo {
+  /** The DOM element of the selected image in the pages container */
+  element: HTMLElement;
+  /** ProseMirror position of the image node */
+  pmPos: number;
+  /** Current width in pixels */
+  width: number;
+  /** Current height in pixels */
+  height: number;
+}
+
+export interface ImageSelectionOverlayProps {
+  /** Info about the currently selected image, or null if no image selected */
+  imageInfo: ImageSelectionInfo | null;
+  /** Zoom level */
+  zoom: number;
+  /** Whether the editor is focused */
+  isFocused: boolean;
+  /** Callback when image is resized */
+  onResize?: (pmPos: number, newWidth: number, newHeight: number) => void;
+  /** Callback when resize starts (to prevent other interactions) */
+  onResizeStart?: () => void;
+  /** Callback when resize ends */
+  onResizeEnd?: () => void;
+  /** Callback when image drag-move completes. Receives drop clientX/clientY. */
+  onDragMove?: (pmPos: number, clientX: number, clientY: number) => void;
+  /** Callback when drag starts */
+  onDragStart?: () => void;
+  /** Callback when drag ends (cancelled or completed) */
+  onDragEnd?: () => void;
+}
+
+// =============================================================================
+// STYLES
+// =============================================================================
+
+const HANDLE_SIZE = 10;
+const HANDLE_HALF = HANDLE_SIZE / 2;
+const BORDER_WIDTH = 2;
+const ACCENT_COLOR = '#2563eb'; // Blue-600
+
+const overlayStyles: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  pointerEvents: 'none',
+  zIndex: 15,
+  overflow: 'visible',
+};
+
+const borderStyles: CSSProperties = {
+  position: 'absolute',
+  border: `${BORDER_WIDTH}px solid ${ACCENT_COLOR}`,
+  pointerEvents: 'none',
+  boxSizing: 'border-box',
+};
+
+const handleBaseStyles: CSSProperties = {
+  position: 'absolute',
+  width: `${HANDLE_SIZE}px`,
+  height: `${HANDLE_SIZE}px`,
+  backgroundColor: ACCENT_COLOR,
+  border: '1px solid white',
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.3)',
+  boxSizing: 'border-box',
+  pointerEvents: 'auto',
+  zIndex: 16,
+};
+
+const dimensionStyles: CSSProperties = {
+  position: 'absolute',
+  backgroundColor: 'rgba(0, 0, 0, 0.75)',
+  color: 'white',
+  fontSize: '11px',
+  fontFamily: 'system-ui, sans-serif',
+  padding: '2px 8px',
+  borderRadius: '3px',
+  whiteSpace: 'nowrap',
+  pointerEvents: 'none',
+  zIndex: 20,
+  transform: 'translateX(-50%)',
+};
+
+const HANDLE_CURSORS: Record<ResizeHandle, string> = {
+  nw: 'nw-resize',
+  ne: 'ne-resize',
+  se: 'se-resize',
+  sw: 'sw-resize',
+};
+
+// =============================================================================
+// RESIZE CALCULATION
+// =============================================================================
+
+function calculateNewDimensions(
+  handle: ResizeHandle,
+  deltaX: number,
+  deltaY: number,
+  startWidth: number,
+  startHeight: number,
+  lockAspect: boolean
+): { width: number; height: number } {
+  const signX = handle.includes('w') ? -1 : 1;
+  const signY = handle.includes('n') ? -1 : 1;
+
+  let newWidth = startWidth + deltaX * signX;
+  let newHeight = startHeight + deltaY * signY;
+
+  if (lockAspect) {
+    const scale = Math.max(newWidth / startWidth, newHeight / startHeight);
+    newWidth = startWidth * scale;
+    newHeight = startHeight * scale;
+  }
+
+  return {
+    width: Math.max(20, Math.min(2000, newWidth)),
+    height: Math.max(20, Math.min(2000, newHeight)),
+  };
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function ImageSelectionOverlay({
+  imageInfo,
+  zoom,
+  isFocused,
+  onResize,
+  onResizeStart,
+  onResizeEnd,
+  onDragMove,
+  onDragStart,
+  onDragEnd,
+}: ImageSelectionOverlayProps): React.ReactElement | null {
+  const [isResizing, setIsResizing] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [resizeWidth, setResizeWidth] = useState(0);
+  const [resizeHeight, setResizeHeight] = useState(0);
+  const [overlayRect, setOverlayRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const rafRef = useRef<number | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Store callbacks in refs so imperative handlers always have latest values
+  const onResizeRef = useRef(onResize);
+  const onResizeStartRef = useRef(onResizeStart);
+  const onResizeEndRef = useRef(onResizeEnd);
+  const onDragMoveRef = useRef(onDragMove);
+  const onDragStartRef = useRef(onDragStart);
+  const onDragEndRef = useRef(onDragEnd);
+  onResizeRef.current = onResize;
+  onResizeStartRef.current = onResizeStart;
+  onResizeEndRef.current = onResizeEnd;
+  onDragMoveRef.current = onDragMove;
+  onDragStartRef.current = onDragStart;
+  onDragEndRef.current = onDragEnd;
+
+  // Store imageInfo and zoom in refs for the imperative mousemove/mouseup handlers
+  const imageInfoRef = useRef(imageInfo);
+  const zoomRef = useRef(zoom);
+  imageInfoRef.current = imageInfo;
+  zoomRef.current = zoom;
+
+  // Update overlay position when imageInfo or layout changes
+  const updatePosition = useCallback(() => {
+    if (!imageInfo || !overlayRef.current) {
+      setOverlayRect(null);
+      return;
+    }
+
+    // Use the overlay's own offsetParent (the viewport div) for correct coordinates
+    const parent = overlayRef.current.offsetParent as HTMLElement | null;
+    if (!parent) {
+      setOverlayRect(null);
+      return;
+    }
+
+    const parentRect = parent.getBoundingClientRect();
+    const imageRect = imageInfo.element.getBoundingClientRect();
+
+    // Calculate position relative to the overlay's positioning parent
+    setOverlayRect({
+      left: (imageRect.left - parentRect.left) / zoom,
+      top: (imageRect.top - parentRect.top) / zoom,
+      width: imageRect.width / zoom,
+      height: imageRect.height / zoom,
+    });
+  }, [imageInfo, zoom]);
+
+  // Update position on mount and when dependencies change
+  useEffect(() => {
+    updatePosition();
+  }, [updatePosition]);
+
+  // Also update on scroll/resize
+  useEffect(() => {
+    if (!imageInfo) return;
+
+    const container =
+      overlayRef.current?.closest('[style*="overflow"]') ??
+      overlayRef.current?.closest('.paged-editor__container');
+    if (!container) return;
+
+    const handleScrollOrResize = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(updatePosition);
+    };
+
+    container.addEventListener('scroll', handleScrollOrResize, { passive: true });
+    window.addEventListener('resize', handleScrollOrResize, { passive: true });
+
+    return () => {
+      container.removeEventListener('scroll', handleScrollOrResize);
+      window.removeEventListener('resize', handleScrollOrResize);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [imageInfo, updatePosition]);
+
+  // Handle resize start - registers window listeners IMMEDIATELY (not via useEffect)
+  // This is critical because browser automation and fast interactions fire
+  // mousedown/mousemove/mouseup synchronously before React can re-render.
+  const handleResizeStart = useCallback(
+    (handle: ResizeHandle, e: React.MouseEvent) => {
+      if (!imageInfo || !overlayRect) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const startWidth = overlayRect.width;
+      const startHeight = overlayRect.height;
+      const startX = e.clientX;
+      const startY = e.clientY;
+
+      // Track final dimensions in local variables (no stale closure issues)
+      let finalWidth = Math.round(startWidth);
+      let finalHeight = Math.round(startHeight);
+
+      setIsResizing(true);
+      setResizeWidth(finalWidth);
+      setResizeHeight(finalHeight);
+      onResizeStartRef.current?.();
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const currentZoom = zoomRef.current;
+        const deltaX = (moveEvent.clientX - startX) / currentZoom;
+        const deltaY = (moveEvent.clientY - startY) / currentZoom;
+        const lockAspect = !moveEvent.shiftKey;
+
+        const dims = calculateNewDimensions(
+          handle,
+          deltaX,
+          deltaY,
+          startWidth,
+          startHeight,
+          lockAspect
+        );
+
+        finalWidth = Math.round(dims.width);
+        finalHeight = Math.round(dims.height);
+        setResizeWidth(finalWidth);
+        setResizeHeight(finalHeight);
+
+        // Update overlay rect for live preview
+        setOverlayRect((prev) => {
+          if (!prev) return prev;
+          const newRect = { ...prev };
+          if (handle.includes('w')) {
+            newRect.left = prev.left + (prev.width - dims.width);
+          }
+          if (handle.includes('n')) {
+            newRect.top = prev.top + (prev.height - dims.height);
+          }
+          newRect.width = dims.width;
+          newRect.height = dims.height;
+          return newRect;
+        });
+      };
+
+      const handleMouseUp = () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+
+        setIsResizing(false);
+
+        // Use the locally tracked final dimensions (always up to date)
+        const info = imageInfoRef.current;
+        if (info) {
+          onResizeRef.current?.(info.pmPos, finalWidth, finalHeight);
+        }
+        onResizeEndRef.current?.();
+      };
+
+      // Register listeners IMMEDIATELY - not in a useEffect
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [imageInfo, overlayRect]
+  );
+
+  // Handle drag-to-move: mousedown on image body (not a handle) starts a move drag
+  const handleBodyMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (!imageInfo || !overlayRect) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const DRAG_THRESHOLD = 4; // px before considering it a drag
+      const startX = e.clientX;
+      const startY = e.clientY;
+      let dragStarted = false;
+      let ghostEl: HTMLElement | null = null;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const dx = moveEvent.clientX - startX;
+        const dy = moveEvent.clientY - startY;
+
+        if (!dragStarted && Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD) {
+          return; // Haven't moved enough to start dragging
+        }
+
+        if (!dragStarted) {
+          dragStarted = true;
+          setIsDragging(true);
+          onDragStartRef.current?.();
+
+          // Create ghost element
+          ghostEl = document.createElement('div');
+          ghostEl.style.cssText =
+            'position: fixed; pointer-events: none; z-index: 10000; ' +
+            'opacity: 0.5; border: 2px dashed #2563eb; border-radius: 4px; ' +
+            'background: rgba(37, 99, 235, 0.1);';
+          ghostEl.style.width = `${overlayRect.width}px`;
+          ghostEl.style.height = `${overlayRect.height}px`;
+          document.body.appendChild(ghostEl);
+        }
+
+        if (ghostEl) {
+          ghostEl.style.left = `${moveEvent.clientX - overlayRect.width / 2}px`;
+          ghostEl.style.top = `${moveEvent.clientY - overlayRect.height / 2}px`;
+        }
+      };
+
+      const handleMouseUp = (upEvent: MouseEvent) => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+
+        if (ghostEl) {
+          ghostEl.remove();
+          ghostEl = null;
+        }
+
+        setIsDragging(false);
+
+        if (dragStarted) {
+          const info = imageInfoRef.current;
+          if (info) {
+            onDragMoveRef.current?.(info.pmPos, upEvent.clientX, upEvent.clientY);
+          }
+          onDragEndRef.current?.();
+        }
+      };
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [imageInfo, overlayRect]
+  );
+
+  // Always render the container div so the ref is available for position calculation.
+  // Use visibility:hidden when not active (keeps offsetParent accessible).
+  const showOverlay = !!(imageInfo && overlayRect && isFocused);
+
+  if (!showOverlay) {
+    return (
+      <div
+        ref={overlayRef}
+        style={{ ...overlayStyles, visibility: 'hidden' }}
+        className="image-selection-overlay"
+      />
+    );
+  }
+
+  const { left, top, width, height } = overlayRect;
+
+  return (
+    <div ref={overlayRef} style={overlayStyles} className="image-selection-overlay">
+      {/* Selection border */}
+      <div
+        style={{
+          ...borderStyles,
+          left: left - BORDER_WIDTH,
+          top: top - BORDER_WIDTH,
+          width: width + BORDER_WIDTH * 2,
+          height: height + BORDER_WIDTH * 2,
+        }}
+      />
+
+      {/* Draggable body area - click and drag to move */}
+      <div
+        style={{
+          position: 'absolute',
+          left,
+          top,
+          width,
+          height,
+          cursor: isDragging ? 'grabbing' : 'grab',
+          pointerEvents: 'auto',
+          zIndex: 15,
+        }}
+        onMouseDown={handleBodyMouseDown}
+      />
+
+      {/* Corner resize handles */}
+      <Handle
+        handle="nw"
+        style={{ left: left - HANDLE_HALF, top: top - HANDLE_HALF }}
+        onMouseDown={handleResizeStart}
+      />
+      <Handle
+        handle="ne"
+        style={{ left: left + width - HANDLE_HALF, top: top - HANDLE_HALF }}
+        onMouseDown={handleResizeStart}
+      />
+      <Handle
+        handle="se"
+        style={{ left: left + width - HANDLE_HALF, top: top + height - HANDLE_HALF }}
+        onMouseDown={handleResizeStart}
+      />
+      <Handle
+        handle="sw"
+        style={{ left: left - HANDLE_HALF, top: top + height - HANDLE_HALF }}
+        onMouseDown={handleResizeStart}
+      />
+
+      {/* Dimension indicator during resize */}
+      {isResizing && (
+        <div
+          style={{
+            ...dimensionStyles,
+            left: left + width / 2,
+            top: top + height + 12,
+          }}
+        >
+          {resizeWidth} × {resizeHeight}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// HANDLE SUB-COMPONENT
+// =============================================================================
+
+interface HandleProps {
+  handle: ResizeHandle;
+  style: CSSProperties;
+  onMouseDown: (handle: ResizeHandle, e: React.MouseEvent) => void;
+}
+
+function Handle({ handle, style, onMouseDown }: HandleProps): React.ReactElement {
+  return (
+    <div
+      style={{
+        ...handleBaseStyles,
+        ...style,
+        cursor: HANDLE_CURSORS[handle],
+      }}
+      onMouseDown={(e) => onMouseDown(handle, e)}
+      data-handle={handle}
+    />
+  );
+}
+
+export default ImageSelectionOverlay;


### PR DESCRIPTION
## Summary

- **Toolbar simplification**: Replace 12 flat image buttons with 3 compact grouped controls (Wrap dropdown, Transform dropdown, Properties button) following the same icon-grid pattern as alignment buttons
- **Image selection overlay**: Blue selection border + 4 corner resize handles + drag-to-move ghost, all in a dedicated overlay component
- **Image drag-and-drop**: Floating images update position EMU attrs on drag; inline images move to exact text position
- **OOXML round-trip fix**: `fromProseDoc.ts` now preserves image `position` (posOffset/relativeTo), `wrapType`, and wrap distances (`distT/B/L/R`) when saving — previously these were silently lost
- **DRY cleanup**: Extract shared `IconGridDropdown` component used by both wrap and transform dropdowns
- **Dead code removal**: Remove unused `onOpenImagePosition` prop chain (YAGNI)

## Files changed

| File | What changed |
|------|-------------|
| `IconGridDropdown.tsx` | NEW — shared dropdown with icon grid, click-outside, Escape |
| `ImageWrapDropdown.tsx` | NEW — thin wrapper (6 wrap types) |
| `ImageTransformDropdown.tsx` | NEW — thin wrapper (4 transforms) |
| `ImageSelectionOverlay.tsx` | NEW — selection border, resize handles, drag-to-move |
| `Toolbar.tsx` | Replace 12 buttons → 3 controls, remove dead prop |
| `DocxEditor.tsx` | Remove dead `onOpenImagePosition` handler + prop |
| `PagedEditor.tsx` | Image selection state, click-to-select, resize, drag handlers |
| `HiddenProseMirror.tsx` | Add `setNodeSelection()` for image node selection |
| `fromProseDoc.ts` | Preserve position/wrap/distances on save (OOXML fix) |
| `renderPage.ts` | Pass `pmStart`/`pmEnd` to floating image DOM elements |
| `renderParagraph.ts` | Update outdated comment about text wrapping |

## Test plan

- [ ] Select an image → toolbar shows Wrap dropdown, Transform dropdown, Properties button
- [ ] Wrap dropdown: click shows 6 icon options, active one highlighted, click applies
- [ ] Transform dropdown: rotate CW/CCW, flip H/V work
- [ ] Click image → blue selection border + resize handles appear
- [ ] Drag resize handle → image resizes with aspect ratio lock
- [ ] Drag image body → ghost follows cursor, drops at new position
- [ ] Open DOCX with floating images → edit → save → reopen → positions preserved
- [ ] `bun run typecheck` passes
- [ ] `npx playwright test tests/formatting.spec.ts tests/alignment.spec.ts tests/lists.spec.ts` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)