### PR TITLE
fix: prevent image OOM crash, constrain to page, fix menu dropdown

### DIFF
--- a/src/components/DocxEditor.tsx
+++ b/src/components/DocxEditor.tsx
@@ -871,18 +871,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           let width = img.naturalWidth;
           let height = img.naturalHeight;
 
-          // Constrain to reasonable max dimensions (content area of US Letter page at 96dpi)
+          // Constrain to reasonable max width (content area of US Letter page at 96dpi)
           const maxWidth = 612; // ~6.375 inches
-          const maxHeight = 792; // ~8.25 inches
           if (width > maxWidth) {
             const scale = maxWidth / width;
             width = maxWidth;
             height = Math.round(height * scale);
-          }
-          if (height > maxHeight) {
-            const scale = maxHeight / height;
-            height = maxHeight;
-            width = Math.round(width * scale);
           }
 
           const rId = `rId_img_${Date.now()}`;

--- a/src/layout-engine/index.ts
+++ b/src/layout-engine/index.ts
@@ -157,17 +157,8 @@ export function layoutDocument(
   const keepNextChains = computeKeepNextChains(blocks);
   const midChainIndices = getMidChainIndices(keepNextChains);
 
-  // Safety limit to prevent runaway page generation (e.g., from measurement bugs)
-  const MAX_PAGES = 500;
-
   // Process each block
   for (let i = 0; i < blocks.length; i++) {
-    if (paginator.pages.length > MAX_PAGES) {
-      console.warn(
-        `[layoutDocument] Page limit (${MAX_PAGES}) exceeded at block ${i}/${blocks.length}. Stopping layout.`
-      );
-      break;
-    }
     const block = blocks[i];
     const measure = measures[i];
 

--- a/src/paged-editor/PagedEditor.tsx
+++ b/src/paged-editor/PagedEditor.tsx
@@ -1231,7 +1231,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         try {
           // Step 1: Convert PM doc to flow blocks
           let stepStart = performance.now();
-          const newBlocks = toFlowBlocks(state.doc, { theme: _theme });
+          const pageContentHeight = pageSize.h - margins.top - margins.bottom;
+          const newBlocks = toFlowBlocks(state.doc, { theme: _theme, pageContentHeight });
           let stepTime = performance.now() - stepStart;
           if (stepTime > 500) {
             console.warn(


### PR DESCRIPTION
## Summary

Fixes #36 — images could cause infinite page generation and OOM crash.

**Root cause:** `measureParagraph` stored image pixel heights in `maxFontSize`, which `calculateTypographyMetrics` then converted via `ptToPx()` — treating pixels as points. A 564px image became a 752px line height (865px with line spacing), exceeding the ~864px page content area and causing runaway page generation.

**Fixes:**
- **Separate image height tracking** — added `maxImageHeightPx` to `LineState` so image heights (already in px) are never passed through `ptToPx()`
- **Constrain images to page in layout pipeline** — `toFlowBlocks` now accepts `pageContentHeight` and scales down oversized images proportionally. Both measurement and rendering read the same constrained dimensions (single source of truth)
- **Fix menu dropdown z-index** — `MenuDropdown` now uses `position: fixed` to escape `overflow: auto` clipping on the toolbar
- **Fix `toFlowBlocks` options propagation** — `opts` was dropping `theme` and other passthrough options; now spreads the original options before applying defaults

**Removed (YAGNI):**
- 500-page safety limit in layout engine (root cause is fixed)
- Hardcoded `maxHeight` in insertion handler (handled properly in `toFlowBlocks`)

## Test plan

- [x] Insert a very tall image (e.g., 500x3000px) — should scale down to fit one page
- [x] Open a DOCX with large images — no OOM, images fit on pages
- [x] Click Insert menu — dropdown renders above editor content
- [x] File menu dropdown works the same way
- [x] Existing image rendering unchanged for normal-sized images

🤖 Generated with [Claude Code](https://claude.com/claude-code)