### PR TITLE
fix: eliminate cumulative layout drift from twips rounding

### DIFF
--- a/src/layout-bridge/toFlowBlocks.ts
+++ b/src/layout-bridge/toFlowBlocks.ts
@@ -70,10 +70,11 @@ function constrainImageToPage(
 const DEFAULT_SIZE = 11; // points (Word 2007+ default)
 
 /**
- * Convert twips to pixels (1 twip = 1/20 point, 1 point = 1.333px at 96 DPI).
+ * Convert twips to pixels (1 twip = 1/1440 inch, 1 inch = 96 CSS px).
+ * No rounding — precision prevents cumulative layout drift across paragraphs.
  */
 function twipsToPixels(twips: number): number {
-  return Math.round((twips / 20) * 1.333);
+  return (twips / 1440) * 96;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix layout shifts where text on page 2+ appears at different positions in the editor vs Word (#37)
- Root cause: `twipsToPixels()` in `toFlowBlocks.ts` used `Math.round()`, losing ~0.3px per paragraph spacing conversion
- Over 15-20 paragraphs on page 1, this accumulated to ~5-6px of drift, shifting page breaks
- Replaced with exact conversion (`twips / 1440 * 96`) matching `utils/units.ts` and `tabCalculator.ts`

## Test plan
- [ ] Load a multi-page document — verify page breaks match Word more closely
- [ ] Add line breaks to push content to page 2 — verify text position matches Word
- [ ] Verify paragraph spacing (before/after) still renders correctly
- [ ] Save and reopen in Word — verify layout consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)