### PR TITLE
fix: treat numId=0 as no-numbering per OOXML spec

### DIFF
--- a/src/layout-bridge/toFlowBlocks.ts
+++ b/src/layout-bridge/toFlowBlocks.ts
@@ -899,7 +899,8 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
           if (pmAttrs.numPr) {
             if (!pmAttrs.listMarker) {
               const numId = pmAttrs.numPr.numId;
-              if (numId == null) break;
+              // numId === 0 means "no numbering" per OOXML spec (ECMA-376)
+              if (numId == null || numId === 0) break;
               const level = pmAttrs.numPr.ilvl ?? 0;
               const counters = listCounters.get(numId) ?? new Array(9).fill(0);
 

--- a/src/prosemirror/conversion/toProseDoc.ts
+++ b/src/prosemirror/conversion/toProseDoc.ts
@@ -298,7 +298,8 @@ function paragraphFormattingToAttrs(
     }
 
     // If style defines numPr but inline doesn't, use style's numPr
-    if (!formatting?.numPr && stylePpr?.numPr) {
+    // numId === 0 means "no numbering" per OOXML spec — skip it
+    if (!formatting?.numPr && stylePpr?.numPr && stylePpr.numPr.numId !== 0) {
       attrs.numPr = stylePpr.numPr;
     }
   } else {


### PR DESCRIPTION
## Summary
- Some DOCX files (especially from Apple Pages) include `numPr` with `numId=0` in `pPrDefault` (paragraph property defaults in `styles.xml`) as an explicit "numbering is off" sentinel
- Per OOXML/ECMA-376 spec, `numId=0` means "no numbering" — it is NOT a valid list reference
- This value was leaking through style resolution into ProseMirror paragraph attributes, causing **every paragraph** to render with spurious numbered list markers (1., 2., 3., etc.)

## Fix (defense in depth)
- **`toFlowBlocks.ts`**: Skip `numId === 0` when computing list markers in the layout bridge
- **`toProseDoc.ts`**: Don't propagate `numPr` with `numId: 0` from resolved style defaults to PM attrs

## Test plan
- [x] `bun run typecheck` passes
- [ ] Load `EP_RJS_20240104.docx` — no spurious numbered list markers on non-list paragraphs
- [ ] Actual list items (items 1-3 in the document) still render with correct numbering
- [ ] Other DOCX files with real numbered lists still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)