### PR TITLE
fix: preserve table/row/cell/image properties on save round-trip

### DIFF
--- a/src/prosemirror/conversion/toProseDoc.ts
+++ b/src/prosemirror/conversion/toProseDoc.ts
@@ -526,6 +526,7 @@ function convertTable(table: Table, styleResolver: StyleResolver | null): PMNode
     floating: table.formatting?.floating,
     cellMargins: cellMarginsAttr,
     look: table.formatting?.look,
+    _originalFormatting: table.formatting || undefined,
   };
 
   const conditionalStyles = {
@@ -628,6 +629,7 @@ function convertTableRow(
     height: row.formatting?.height?.value,
     heightRule: row.formatting?.heightRule,
     isHeader: isHeaderRow || row.formatting?.header,
+    _originalFormatting: row.formatting || undefined,
   };
 
   const numCells = row.cells.length;
@@ -890,6 +892,7 @@ function convertTableCell(
             right: conditionalStyle.tcPr.margins.right?.value,
           }
         : defaultCellMargins,
+    _originalFormatting: formatting || undefined,
   };
 
   // Convert cell content (paragraphs and nested tables)
@@ -1318,6 +1321,7 @@ function convertImage(image: Image): PMNode {
     borderWidth: borderWidth,
     borderColor: borderColor,
     borderStyle: borderStyle,
+    wrapText: wrapText,
   });
 }
 

--- a/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -31,6 +31,7 @@ export const ImageExtension = createNodeExtension({
       borderWidth: { default: null },
       borderColor: { default: null },
       borderStyle: { default: null },
+      wrapText: { default: null },
     },
     parseDOM: [
       {

--- a/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -44,6 +44,7 @@ const tableSpec: NodeSpec = {
     floating: { default: null },
     cellMargins: { default: null },
     look: { default: null },
+    _originalFormatting: { default: null },
   },
   parseDOM: [
     {
@@ -98,6 +99,7 @@ const tableRowSpec: NodeSpec = {
     height: { default: null },
     heightRule: { default: null },
     isHeader: { default: false },
+    _originalFormatting: { default: null },
   },
   parseDOM: [{ tag: 'tr' }],
   toDOM(node) {
@@ -248,6 +250,7 @@ const tableCellSpec: NodeSpec = {
     margins: { default: null },
     textDirection: { default: null },
     noWrap: { default: false },
+    _originalFormatting: { default: null },
   },
   parseDOM: [
     {
@@ -313,6 +316,7 @@ const tableHeaderSpec: NodeSpec = {
     margins: { default: null },
     textDirection: { default: null },
     noWrap: { default: false },
+    _originalFormatting: { default: null },
   },
   parseDOM: [
     {

--- a/src/prosemirror/schema/nodes.ts
+++ b/src/prosemirror/schema/nodes.ts
@@ -15,6 +15,9 @@ import type {
   TabStop,
   TextFormatting,
   NumberFormat,
+  TableFormatting,
+  TableRowFormatting,
+  TableCellFormatting,
 } from '../../types/document';
 import type { FloatingTableProperties, TableLook } from '../../types';
 
@@ -149,6 +152,8 @@ export interface ImageAttrs {
   borderColor?: string;
   /** Border style (CSS border-style value) */
   borderStyle?: string;
+  /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */
+  wrapText?: string;
 }
 
 /**
@@ -171,6 +176,8 @@ export interface TableAttrs {
   cellMargins?: { top?: number; bottom?: number; left?: number; right?: number };
   /** Table look flags for conditional formatting (w:tblLook) */
   look?: TableLook;
+  /** Original table formatting from DOCX for lossless round-trip serialization */
+  _originalFormatting?: TableFormatting;
 }
 
 /**
@@ -183,6 +190,8 @@ export interface TableRowAttrs {
   heightRule?: string;
   /** Is header row */
   isHeader?: boolean;
+  /** Original row formatting from DOCX for lossless round-trip serialization */
+  _originalFormatting?: TableRowFormatting;
 }
 
 /**
@@ -211,4 +220,6 @@ export interface TableCellAttrs {
   borders?: { top?: BorderSpec; bottom?: BorderSpec; left?: BorderSpec; right?: BorderSpec };
   /** Cell margins/padding in twips per side */
   margins?: { top?: number; bottom?: number; left?: number; right?: number };
+  /** Original cell formatting from DOCX for lossless round-trip serialization */
+  _originalFormatting?: TableCellFormatting;
 }


### PR DESCRIPTION
## Summary

- **Lossless table round-trip**: Tables, rows, and cells now store `_originalFormatting` (same pattern as paragraphs), preserving ~15 properties that were silently dropped on save: `cellSpacing`, `indent`, `layout`, `bidi`, `overlap`, `shading` (table); `cantSplit`, `justification`, `hidden`, `conditionalFormat` (row); `vMerge`, `fitText`, `hideMark`, `conditionalFormat` (cell)
- **Image transform round-trip**: Rotation and flip (`scaleX(-1)`/`scaleY(-1)`) are now parsed back from the CSS transform string to `ImageTransform` on save
- **Image wrapText round-trip**: The `wrapText` property (`left`/`right`/`bothSides`/`largest`) is now stored as a PM attr and restored on save
- **Cell width=0 fix**: `width=0` was treated as falsy, causing formatting to be skipped — now uses `!= null` check

## Files changed (5)

| File | Change |
|------|--------|
| `src/prosemirror/schema/nodes.ts` | Add `_originalFormatting` to 3 table interfaces + `wrapText` to `ImageAttrs` |
| `src/prosemirror/extensions/nodes/TableExtension.ts` | Add `_originalFormatting` attr to 4 NodeSpecs (table, row, cell, header) |
| `src/prosemirror/extensions/nodes/ImageExtension.ts` | Add `wrapText` attr to image NodeSpec |
| `src/prosemirror/conversion/toProseDoc.ts` | Store `_originalFormatting` for table/row/cell + `wrapText` for image during parse |
| `src/prosemirror/conversion/fromProseDoc.ts` | Use `_originalFormatting` as base in 3 serialization functions, parse image transform, restore wrapText, fix cell width=0 |

## How to verify

### Table properties preserved
1. Create a DOCX in Word with complex table formatting (cellSpacing, bidi text, cantSplit rows, conditional formatting)
2. Open in editor → save → unzip both files → diff `word/document.xml`
3. The table/row/cell XML elements should now retain all original attributes

### Image transform preserved
1. Create a DOCX with a rotated or flipped image in Word
2. Open in editor → save → check `<a:xfrm rot="..." flipH="1">` in output XML

### Cell width=0 fix
1. Create a DOCX with a table cell using `<w:tcW w:w="0" w:type="auto"/>`
2. Open in editor → save → verify `w:tcW` element is preserved (was being dropped)

## Test plan

- [x] `bun run typecheck` — passes
- [x] `npx playwright test e2e/tests/image-roundtrip.spec.ts` — 3/3 pass
- [x] `npx playwright test e2e/tests/formatting.spec.ts` — same pre-existing failures, no regressions
- [ ] Manual: open complex table DOCX → save → XML diff
- [ ] Manual: open rotated image DOCX → save → verify transform in XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)