### PR TITLE
fix: cursor height, font inheritance on Enter, and <11pt line metrics

### DIFF
--- a/src/layout-bridge/measuring/measureParagraph.ts
+++ b/src/layout-bridge/measuring/measureParagraph.ts
@@ -454,7 +454,10 @@ export function measureParagraph(
    */
   const updateMaxFont = (style: FontStyle): void => {
     const fontSize = style.fontSize ?? DEFAULT_FONT_SIZE;
-    if (fontSize > currentLine.maxFontSize) {
+    // Update when this is the first run on the line (maxFontMetrics not yet set)
+    // or when we find a larger font size. Without the !maxFontMetrics check,
+    // lines with only <11pt text would use the 11pt default, inflating line height.
+    if (!currentLine.maxFontMetrics || fontSize > currentLine.maxFontSize) {
       currentLine.maxFontSize = fontSize;
       currentLine.maxFontMetrics = getFontMetrics(style);
     }

--- a/src/layout-bridge/selectionRects.ts
+++ b/src/layout-bridge/selectionRects.ts
@@ -585,7 +585,7 @@ export function getCaretPosition(
             return {
               x: fragment.x + indentLeft + alignmentOffset + x,
               y: fragment.y + lineOffset + pageTopY,
-              height: line.lineHeight,
+              height: line.ascent + line.descent,
               pageIndex,
             };
           }

--- a/src/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/src/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -16,7 +16,7 @@ import {
 import { createExtension } from '../create';
 import { Priority } from '../types';
 import type { ExtensionRuntime, ExtensionContext } from '../types';
-import type { Command } from 'prosemirror-state';
+import type { Command, Transaction } from 'prosemirror-state';
 
 function chainCommands(...commands: Command[]): Command {
   return (state, dispatch, view) => {
@@ -69,32 +69,117 @@ const clearIndentOnBackspace: Command = (state, dispatch) => {
 };
 
 /**
- * Custom Enter handler that splits the block and clears paragraph borders
- * on the new paragraph. In Word, pressing Enter does NOT propagate paragraph
- * borders (w:pBdr) to the new paragraph. This matches that behavior.
+ * Custom Enter handler: splits the block, inherits style-related attrs,
+ * clears paragraph borders, and preserves font marks on the new paragraph.
+ *
+ * splitBlock creates a new paragraph with default attrs (all null),
+ * so we must manually copy style-related attrs from the source paragraph.
+ * Word does NOT propagate paragraph borders (w:pBdr) on Enter.
  */
+const INHERITED_PARA_ATTRS = [
+  'defaultTextFormatting',
+  'styleId',
+  'lineSpacing',
+  'lineSpacingRule',
+  'spaceAfter',
+  'spaceBefore',
+  'contextualSpacing',
+] as const;
+
+/** Mark types that represent style-inherited formatting (font, size, color). */
+const STYLE_MARK_NAMES = new Set(['fontFamily', 'fontSize', 'textColor']);
+
 const splitBlockClearBorders: Command = (state, dispatch, view) => {
-  // First, perform the standard split
-  if (!splitBlock(state, dispatch, view)) {
+  // Capture source paragraph info BEFORE split (splitBlock resets everything)
+  const { $from: preSplitFrom } = state.selection;
+  const sourcePara = preSplitFrom.parent.type.name === 'paragraph' ? preSplitFrom.parent : null;
+
+  // Collect style marks from the cursor position before splitting.
+  // Use storedMarks if set, otherwise resolve from the position.
+  const preMarks = state.storedMarks || preSplitFrom.marks();
+  const styleMarks = preMarks.filter((m) => STYLE_MARK_NAMES.has(m.type.name));
+
+  // Intercept splitBlock's transaction so we can modify it before dispatch.
+  // This ensures attrs + stored marks are set in a single transaction,
+  // avoiding a flash where the empty paragraph has no formatting.
+  let splitTr: Transaction | null = null;
+  const capturingDispatch = dispatch
+    ? (tr: Transaction) => {
+        splitTr = tr;
+      }
+    : undefined;
+
+  if (!splitBlock(state, capturingDispatch, view)) {
     return false;
   }
 
-  // After split, the cursor is in the new (second) paragraph.
-  // We need to clear borders on it. Since splitBlock already dispatched,
-  // we need to work with the updated state from the view.
-  if (dispatch && view) {
-    const newState = view.state;
-    const { $from } = newState.selection;
-    const paragraph = $from.parent;
+  if (dispatch && splitTr !== null) {
+    // After split, cursor is in the new (second) paragraph.
+    // Apply attr inheritance, border clearing, and stored marks to the SAME transaction.
+    const tr = splitTr as Transaction;
+    const { $from } = tr.selection;
+    const newPara = $from.parent;
 
-    if (paragraph.type.name === 'paragraph' && paragraph.attrs.borders) {
-      const pos = $from.before();
-      const tr = newState.tr.setNodeMarkup(pos, undefined, {
-        ...paragraph.attrs,
-        borders: null,
-      });
-      dispatch(tr.scrollIntoView());
+    if (newPara.type.name === 'paragraph') {
+      const newAttrs = { ...newPara.attrs };
+      let attrsChanged = false;
+
+      // Copy inherited attrs from source paragraph
+      if (sourcePara) {
+        for (const key of INHERITED_PARA_ATTRS) {
+          const srcVal = sourcePara.attrs[key];
+          if (srcVal != null && newAttrs[key] == null) {
+            newAttrs[key] = srcVal;
+            attrsChanged = true;
+          }
+        }
+      }
+
+      // Clear borders (Word does not propagate paragraph borders on Enter)
+      if (newAttrs.borders) {
+        newAttrs.borders = null;
+        attrsChanged = true;
+      }
+
+      if (attrsChanged) {
+        tr.setNodeMarkup($from.before(), undefined, newAttrs);
+      }
+
+      // For empty paragraphs (Enter at end of line), set stored marks so typed text
+      // inherits font family, font size, and text color. We skip bold/italic/etc —
+      // Word doesn't carry direct formatting to new paragraphs.
+      if (newPara.textContent.length === 0 && styleMarks.length > 0) {
+        // Sync defaultTextFormatting with the actual cursor marks so the empty
+        // paragraph measurement (used for caret height) matches the stored marks.
+        const dtf = { ...(newAttrs.defaultTextFormatting ?? {}) };
+        let dtfChanged = false;
+        for (const m of styleMarks) {
+          if (m.type.name === 'fontSize' && m.attrs.size !== dtf.fontSize) {
+            dtf.fontSize = m.attrs.size;
+            dtfChanged = true;
+          }
+          if (m.type.name === 'fontFamily') {
+            const ascii = m.attrs.ascii as string | undefined;
+            if (ascii && (!dtf.fontFamily || dtf.fontFamily.ascii !== ascii)) {
+              dtf.fontFamily = { ...dtf.fontFamily, ascii, hAnsi: m.attrs.hAnsi };
+              dtfChanged = true;
+            }
+          }
+        }
+        if (dtfChanged) {
+          tr.setNodeMarkup($from.before(), undefined, {
+            ...newAttrs,
+            defaultTextFormatting: dtf,
+          });
+        }
+
+        // IMPORTANT: setStoredMarks MUST be called AFTER all setNodeMarkup calls.
+        // setNodeMarkup adds a ReplaceStep which clears storedMarks on the transaction.
+        tr.setStoredMarks(styleMarks);
+      }
     }
+
+    dispatch(tr.scrollIntoView());
   }
 
   return true;


### PR DESCRIPTION
## Summary

- **Cursor height**: use `ascent + descent` instead of `lineHeight` so the caret matches actual font glyph height rather than being inflated by the line spacing multiplier (e.g. 1.15x)
- **Font inheritance on Enter**: rewrite `splitBlockClearBorders` to capture marks before `splitBlock`, then restore style-inherited marks (fontFamily, fontSize, textColor) on the new empty paragraph — matches Word behavior where bold/italic are NOT carried over
- **<11pt line metrics**: fix `measureParagraph` initializing `maxFontSize` to 11pt default, which inflated line heights for paragraphs with only smaller fonts (e.g. 8.5pt Garamond)

## Details

### Cursor height (`selectionRects.ts`)
Changed caret height from `line.lineHeight` to `line.ascent + line.descent`.

### Font on Enter (`BaseKeymapExtension.ts`)
- Intercept `splitBlock`'s dispatch to modify the transaction in a single pass
- Copy `INHERITED_PARA_ATTRS` (styleId, lineSpacing, contextualSpacing, etc.) from source paragraph
- Clear borders (Word does not propagate `w:pBdr` on Enter)
- Sync `defaultTextFormatting` with cursor marks for correct caret height on empty paragraphs
- **Critical fix**: `setStoredMarks()` must be called AFTER all `setNodeMarkup()` calls — `setNodeMarkup` adds a `ReplaceStep` that clears stored marks

### Small font metrics (`measureParagraph.ts`)
Changed `updateMaxFont` to set metrics from the first run on a line (when `maxFontMetrics` is null), not only when fontSize exceeds the 11pt default.

## Test plan

- [x] `bun run typecheck` passes
- [x] Playwright `text-editing.spec.ts` — 34/34 pass
- [x] Visual: Enter in Garamond 11pt body text → toolbar shows Garamond 11, typed text is Garamond
- [x] Visual: Enter in Garamond 8.5pt signature area → toolbar shows Garamond 8.5, typed text is Garamond 8.5
- [x] Visual: cursor height matches font size (not oversized from spacing multiplier)
- [x] Bold/italic NOT carried over on Enter (Word behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)