### PR TITLE
feat: add docx loremify sanitizer for confidential bug reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,20 @@ Open an issue at [github.com/eigenpal/docx-js-editor/issues](https://github.com/
 - Expected vs actual behavior
 - Attach a `.docx` file if relevant (remove sensitive content first)
 
+### Sanitizing DOCX Files for Bug Reports
+
+If your source document contains confidential text, you can generate a sanitized copy that keeps layout/formatting while replacing text content:
+
+```bash
+# Create a sanitized copy next to the original file
+bun run docx:loremify -- "path/to/file.docx"
+
+# Or write sanitized files to a folder
+bun run docx:loremify -- "path/to/file.docx" --out-dir sanitized-docs
+```
+
+The script preserves DOCX structure (tables, nesting, headers/footers, styles) and replaces words with lorem-style text while preserving per-word lengths.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,13 @@ bun run docx:loremify -- "path/to/file.docx"
 
 # Or write sanitized files to a folder
 bun run docx:loremify -- "path/to/file.docx" --out-dir sanitized-docs
+
+# Also remove embedded media (images/screenshots/logos)
+bun run docx:loremify -- "path/to/file.docx" --strip-media
 ```
 
-The script preserves DOCX structure (tables, nesting, headers/footers, styles) and replaces words with lorem-style text while preserving per-word lengths.
+The script preserves DOCX structure (tables, nesting, headers/footers, styles), sanitizes document metadata in `docProps/core.xml` and `docProps/app.xml`, and replaces words with lorem-style text while preserving per-word lengths. Numeric characters are preserved.
+If you pass `--strip-media`, it also removes `word/media/*` files and image references from Word XML/relationship parts.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
     "test:visual": "npx playwright test visual.spec.ts",
+    "docx:loremify": "bun scripts/loremify-docx.ts",
     "prepublishOnly": "bun test && NODE_ENV=production bun run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",

--- a/scripts/loremify-docx.test.ts
+++ b/scripts/loremify-docx.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'path';
+import {
+  LoremWordGenerator,
+  applyCasing,
+  decodeXmlEntities,
+  loremifyXml,
+  parseArgs,
+  sanitizeMetadataXml,
+  stripMediaMarkupFromWordXml,
+  stripMediaReferencesFromRels,
+} from './loremify-docx';
+
+describe('loremify-docx helpers', () => {
+  test('applyCasing preserves upper, title, and lower casing', () => {
+    expect(applyCasing('HELLO', 'ipsum')).toBe('IPSUM');
+    expect(applyCasing('Hello', 'ipsum')).toBe('Ipsum');
+    expect(applyCasing('hello', 'IPSUM')).toBe('ipsum');
+  });
+
+  test('decodeXmlEntities decodes named and numeric entities', () => {
+    expect(decodeXmlEntities('A &amp; B')).toBe('A & B');
+    expect(decodeXmlEntities('&#65;&#x42;')).toBe('AB');
+    expect(decodeXmlEntities('&unknown;')).toBe('&unknown;');
+  });
+
+  test('parseArgs parses options and resolves inputs', () => {
+    const options = parseArgs([
+      'sample.docx',
+      '--out-dir',
+      'sanitized',
+      '--suffix',
+      '.anon',
+      '--all-xml',
+      '--strip-media',
+    ]);
+
+    expect(options.inputs).toEqual([path.resolve('sample.docx')]);
+    expect(options.outDir).toBe(path.resolve('sanitized'));
+    expect(options.suffix).toBe('.anon');
+    expect(options.allXml).toBe(true);
+    expect(options.stripMedia).toBe(true);
+  });
+
+  test('parseArgs rejects unknown options', () => {
+    expect(() => parseArgs(['sample.docx', '--unknown'])).toThrow('Unknown option: --unknown');
+  });
+
+  test('loremifyXml preserves numeric text while replacing words', () => {
+    const inputXml =
+      '<w:document><w:body><w:p><w:r><w:t>Invoice 2026-01-15 A1B2</w:t></w:r></w:p></w:body></w:document>';
+    const result = loremifyXml(inputXml, new LoremWordGenerator());
+
+    expect(result.replacedWords).toBe(3);
+    expect(result.xml).toContain('<w:t>Loremlo 2026-01-15 I1D2</w:t>');
+  });
+
+  test('sanitizeMetadataXml sanitizes core and app properties', () => {
+    const coreXml =
+      '<cp:coreProperties><dc:creator>Alice</dc:creator><cp:lastModifiedBy>Bob</cp:lastModifiedBy><cp:revision>42</cp:revision></cp:coreProperties>';
+    const appXml =
+      '<Properties><Company>Acme</Company><Manager>Carol</Manager><HyperlinkBase>https://example.com</HyperlinkBase></Properties>';
+
+    const sanitizedCore = sanitizeMetadataXml('docProps/core.xml', coreXml);
+    const sanitizedApp = sanitizeMetadataXml('docProps/app.xml', appXml);
+
+    expect(sanitizedCore.sanitizedFields).toBe(3);
+    expect(sanitizedCore.xml).toContain('<dc:creator>Sanitized</dc:creator>');
+    expect(sanitizedCore.xml).toContain('<cp:lastModifiedBy>Sanitized</cp:lastModifiedBy>');
+    expect(sanitizedCore.xml).toContain('<cp:revision>1</cp:revision>');
+
+    expect(sanitizedApp.sanitizedFields).toBe(3);
+    expect(sanitizedApp.xml).toContain('<Company>Sanitized</Company>');
+    expect(sanitizedApp.xml).toContain('<Manager>Sanitized</Manager>');
+    expect(sanitizedApp.xml).toContain('<HyperlinkBase></HyperlinkBase>');
+  });
+
+  test('stripMediaReferencesFromRels removes media relationships only', () => {
+    const relsXml = `<Relationships>
+  <Relationship Id="rId1" Target="media/image1.png" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
+  <Relationship Id="rId2" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>`;
+
+    const stripped = stripMediaReferencesFromRels(relsXml);
+    expect(stripped).not.toContain('media/image1.png');
+    expect(stripped).toContain('styles.xml');
+  });
+
+  test('stripMediaMarkupFromWordXml removes drawing and pict blocks', () => {
+    const wordXml = `<w:p>
+  <w:r><w:drawing><wp:inline>img</wp:inline></w:drawing></w:r>
+  <w:r><w:pict><v:shape/></w:pict></w:r>
+  <w:r><w:t>Keep me</w:t></w:r>
+</w:p>`;
+
+    const stripped = stripMediaMarkupFromWordXml(wordXml);
+    expect(stripped).not.toContain('<w:drawing>');
+    expect(stripped).not.toContain('<w:pict>');
+    expect(stripped).toContain('<w:t>Keep me</w:t>');
+  });
+});

--- a/scripts/loremify-docx.ts
+++ b/scripts/loremify-docx.ts
@@ -1,0 +1,375 @@
+/**
+ * DOCX Loremifier
+ *
+ * Replaces human-readable run text in DOCX XML parts with lorem-ipsum-like
+ * text while preserving document structure and per-word lengths.
+ *
+ * Usage:
+ *   bun run docx:loremify -- input.docx
+ *   bun run docx:loremify -- input.docx --out-dir sanitized
+ *   bun run docx:loremify -- input1.docx input2.docx --suffix .anon
+ *   bun run docx:loremify -- input.docx --in-place
+ */
+
+import JSZip from 'jszip';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+type CliOptions = {
+  help: boolean;
+  inPlace: boolean;
+  allXml: boolean;
+  outDir?: string;
+  suffix: string;
+  inputs: string[];
+};
+
+type FileStats = {
+  xmlFilesUpdated: number;
+  wordsReplaced: number;
+};
+
+const HELP_TEXT = `docx loremifier
+
+USAGE:
+  bun run docx:loremify -- <input1.docx> [input2.docx ...] [options]
+
+OPTIONS:
+  --out-dir <dir>   Output directory for generated files
+  --suffix <text>   Output filename suffix (default: .lorem)
+  --in-place        Overwrite original file(s)
+  --all-xml         Replace text in every XML part (advanced)
+  -h, --help        Show this help text
+
+EXAMPLES:
+  bun run docx:loremify -- sample.docx
+  bun run docx:loremify -- sample.docx --out-dir sanitized
+  bun run docx:loremify -- a.docx b.docx --suffix .anonymized
+  bun run docx:loremify -- sample.docx --in-place
+`;
+
+const LOREM_WORDS = [
+  'lorem',
+  'ipsum',
+  'dolor',
+  'sit',
+  'amet',
+  'consectetur',
+  'adipiscing',
+  'elit',
+  'sed',
+  'do',
+  'eiusmod',
+  'tempor',
+  'incididunt',
+  'ut',
+  'labore',
+  'et',
+  'dolore',
+  'magna',
+  'aliqua',
+];
+
+const TEXT_TAG_PATTERNS = [
+  /<((?:[\w.-]+:)?t)(\s[^>]*)?>([\s\S]*?)<\/\1>/g,
+  /<((?:[\w.-]+:)?delText)(\s[^>]*)?>([\s\S]*?)<\/\1>/g,
+];
+
+const XML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+class LoremWordGenerator {
+  private index = 0;
+
+  next(wordLength: number): string {
+    if (wordLength <= 0) return '';
+
+    const base = LOREM_WORDS[this.index % LOREM_WORDS.length];
+    this.index += 1;
+    return fitWordToLength(base, wordLength);
+  }
+}
+
+function fitWordToLength(base: string, targetLength: number): string {
+  if (targetLength <= base.length) {
+    return base.slice(0, targetLength);
+  }
+
+  let value = '';
+  while (value.length < targetLength) {
+    value += base;
+  }
+  return value.slice(0, targetLength);
+}
+
+function applyCasing(source: string, replacement: string): string {
+  if (source.toUpperCase() === source) {
+    return replacement.toUpperCase();
+  }
+
+  if (
+    source.length > 0 &&
+    source[0] === source[0].toUpperCase() &&
+    source.slice(1) === source.slice(1).toLowerCase()
+  ) {
+    return replacement[0].toUpperCase() + replacement.slice(1).toLowerCase();
+  }
+
+  if (source.toLowerCase() === source) {
+    return replacement.toLowerCase();
+  }
+
+  return replacement;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-fA-F]+|amp|lt|gt|quot|apos);/g, (full, entity) => {
+    if (entity in XML_ENTITIES) {
+      return XML_ENTITIES[entity];
+    }
+
+    if (entity.startsWith('#x')) {
+      const codePoint = Number.parseInt(entity.slice(2), 16);
+      if (!Number.isNaN(codePoint) && codePoint >= 0) {
+        return String.fromCodePoint(codePoint);
+      }
+      return full;
+    }
+
+    if (entity.startsWith('#')) {
+      const codePoint = Number.parseInt(entity.slice(1), 10);
+      if (!Number.isNaN(codePoint) && codePoint >= 0) {
+        return String.fromCodePoint(codePoint);
+      }
+      return full;
+    }
+
+    return full;
+  });
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function replaceWordsKeepingLengths(
+  value: string,
+  generator: LoremWordGenerator
+): { text: string; replacedWords: number } {
+  let replacedWords = 0;
+  const text = value.replace(/[\p{L}\p{N}]+/gu, (word) => {
+    replacedWords += 1;
+    const replacement = generator.next(word.length);
+    return applyCasing(word, replacement);
+  });
+
+  return { text, replacedWords };
+}
+
+function loremifyXml(xml: string, generator: LoremWordGenerator): { xml: string; replacedWords: number } {
+  let updatedXml = xml;
+  let replacedWords = 0;
+
+  for (const pattern of TEXT_TAG_PATTERNS) {
+    updatedXml = updatedXml.replace(pattern, (full, tagName: string, attrs: string, text: string) => {
+      const decoded = decodeXmlEntities(text);
+      const result = replaceWordsKeepingLengths(decoded, generator);
+      replacedWords += result.replacedWords;
+
+      if (result.replacedWords === 0) {
+        return full;
+      }
+
+      const safeText = escapeXmlText(result.text);
+      return `<${tagName}${attrs ?? ''}>${safeText}</${tagName}>`;
+    });
+  }
+
+  return { xml: updatedXml, replacedWords };
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    help: false,
+    inPlace: false,
+    allXml: false,
+    suffix: '.lorem',
+    inputs: [],
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--in-place') {
+      options.inPlace = true;
+      continue;
+    }
+
+    if (arg === '--all-xml') {
+      options.allXml = true;
+      continue;
+    }
+
+    if (arg === '--out-dir') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('--out-dir requires a directory path');
+      }
+      options.outDir = path.resolve(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--suffix') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('--suffix requires a value');
+      }
+      options.suffix = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    options.inputs.push(path.resolve(arg));
+  }
+
+  return options;
+}
+
+function getOutputPath(inputPath: string, options: CliOptions): string {
+  if (options.inPlace) {
+    return inputPath;
+  }
+
+  const ext = path.extname(inputPath) || '.docx';
+  const stem = path.basename(inputPath, ext);
+  const outputDir = options.outDir ?? path.dirname(inputPath);
+  return path.join(outputDir, `${stem}${options.suffix}${ext}`);
+}
+
+async function loremifyDocxBuffer(
+  buffer: Buffer,
+  options: Pick<CliOptions, 'allXml'>
+): Promise<{ output: Buffer; stats: FileStats }> {
+  const zip = await JSZip.loadAsync(buffer);
+  const generator = new LoremWordGenerator();
+
+  let xmlFilesUpdated = 0;
+  let wordsReplaced = 0;
+
+  for (const [zipPath, zipFile] of Object.entries(zip.files)) {
+    if (zipFile.dir || !zipPath.toLowerCase().endsWith('.xml')) {
+      continue;
+    }
+
+    if (!shouldProcessXmlPart(zipPath, options.allXml)) {
+      continue;
+    }
+
+    const xml = await zipFile.async('text');
+    const result = loremifyXml(xml, generator);
+    wordsReplaced += result.replacedWords;
+
+    if (result.xml !== xml) {
+      xmlFilesUpdated += 1;
+      zip.file(zipPath, result.xml, {
+        compression: 'DEFLATE',
+        compressionOptions: { level: 6 },
+      });
+    }
+  }
+
+  const output = await zip.generateAsync({
+    type: 'nodebuffer',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 },
+  });
+
+  return {
+    output,
+    stats: { xmlFilesUpdated, wordsReplaced },
+  };
+}
+
+function shouldProcessXmlPart(zipPath: string, allXml: boolean): boolean {
+  if (allXml) {
+    return true;
+  }
+
+  const lower = zipPath.toLowerCase();
+  if (lower === 'word/document.xml') return true;
+  if (lower === 'word/footnotes.xml') return true;
+  if (lower === 'word/endnotes.xml') return true;
+  if (lower === 'word/comments.xml') return true;
+  if (lower === 'word/commentsextensible.xml') return true;
+  if (lower === 'word/commentsextended.xml') return true;
+
+  if (/^word\/header\d+\.xml$/.test(lower)) return true;
+  if (/^word\/footer\d+\.xml$/.test(lower)) return true;
+
+  return false;
+}
+
+async function processFile(inputPath: string, options: CliOptions): Promise<void> {
+  if (!inputPath.toLowerCase().endsWith('.docx')) {
+    throw new Error(`Expected a .docx file: ${inputPath}`);
+  }
+
+  const outputPath = getOutputPath(inputPath, options);
+  const source = await fs.readFile(inputPath);
+  const result = await loremifyDocxBuffer(source, options);
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, result.output);
+
+  console.log(
+    [
+      `Input: ${inputPath}`,
+      `Output: ${outputPath}`,
+      `Updated XML files: ${result.stats.xmlFilesUpdated}`,
+      `Words replaced: ${result.stats.wordsReplaced}`,
+      '',
+    ].join('\n')
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (options.inputs.length === 0) {
+    throw new Error('At least one input .docx file is required. Use --help for usage.');
+  }
+
+  if (options.inPlace && options.outDir) {
+    throw new Error('--in-place and --out-dir cannot be used together');
+  }
+
+  for (const inputPath of options.inputs) {
+    await processFile(inputPath, options);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});

--- a/scripts/loremify-docx.ts
+++ b/scripts/loremify-docx.ts
@@ -19,6 +19,7 @@ type CliOptions = {
   help: boolean;
   inPlace: boolean;
   allXml: boolean;
+  stripMedia: boolean;
   outDir?: string;
   suffix: string;
   inputs: string[];
@@ -27,6 +28,8 @@ type CliOptions = {
 type FileStats = {
   xmlFilesUpdated: number;
   wordsReplaced: number;
+  mediaFilesRemoved: number;
+  metadataFieldsSanitized: number;
 };
 
 const HELP_TEXT = `docx loremifier
@@ -39,6 +42,7 @@ OPTIONS:
   --suffix <text>   Output filename suffix (default: .lorem)
   --in-place        Overwrite original file(s)
   --all-xml         Replace text in every XML part (advanced)
+  --strip-media     Remove embedded files in word/media and image references
   -h, --help        Show this help text
 
 EXAMPLES:
@@ -83,7 +87,25 @@ const XML_ENTITIES: Record<string, string> = {
   apos: "'",
 };
 
-class LoremWordGenerator {
+const CORE_PROPERTIES_RULES: Array<{ tagName: string; replacement: string }> = [
+  { tagName: 'dc:creator', replacement: 'Sanitized' },
+  { tagName: 'cp:lastModifiedBy', replacement: 'Sanitized' },
+  { tagName: 'cp:revision', replacement: '1' },
+  { tagName: 'dc:title', replacement: '' },
+  { tagName: 'dc:subject', replacement: '' },
+  { tagName: 'dc:description', replacement: '' },
+  { tagName: 'cp:keywords', replacement: '' },
+  { tagName: 'cp:category', replacement: '' },
+  { tagName: 'cp:contentStatus', replacement: '' },
+];
+
+const APP_PROPERTIES_RULES: Array<{ tagName: string; replacement: string }> = [
+  { tagName: 'Company', replacement: 'Sanitized' },
+  { tagName: 'Manager', replacement: 'Sanitized' },
+  { tagName: 'HyperlinkBase', replacement: '' },
+];
+
+export class LoremWordGenerator {
   private index = 0;
 
   next(wordLength: number): string {
@@ -107,7 +129,7 @@ function fitWordToLength(base: string, targetLength: number): string {
   return value.slice(0, targetLength);
 }
 
-function applyCasing(source: string, replacement: string): string {
+export function applyCasing(source: string, replacement: string): string {
   if (source.toUpperCase() === source) {
     return replacement.toUpperCase();
   }
@@ -127,7 +149,7 @@ function applyCasing(source: string, replacement: string): string {
   return replacement;
 }
 
-function decodeXmlEntities(value: string): string {
+export function decodeXmlEntities(value: string): string {
   return value.replace(/&(#x?[0-9a-fA-F]+|amp|lt|gt|quot|apos);/g, (full, entity) => {
     if (entity in XML_ENTITIES) {
       return XML_ENTITIES[entity];
@@ -157,12 +179,89 @@ function escapeXmlText(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function replaceWordsKeepingLengths(
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceTagValue(
+  xml: string,
+  tagName: string,
+  replacement: string
+): { xml: string; replacements: number } {
+  const pattern = new RegExp(
+    `<(${escapeRegex(tagName)})(\\s[^>]*)?>([\\s\\S]*?)<\\/\\1>`,
+    'g'
+  );
+
+  let replacements = 0;
+  const updatedXml = xml.replace(pattern, (_full, fullTagName: string, attrs: string) => {
+    replacements += 1;
+    return `<${fullTagName}${attrs ?? ''}>${escapeXmlText(replacement)}</${fullTagName}>`;
+  });
+
+  return { xml: updatedXml, replacements };
+}
+
+export function sanitizeMetadataXml(zipPath: string, xml: string): { xml: string; sanitizedFields: number } {
+  const lower = zipPath.toLowerCase();
+  const rules =
+    lower === 'docprops/core.xml'
+      ? CORE_PROPERTIES_RULES
+      : lower === 'docprops/app.xml'
+        ? APP_PROPERTIES_RULES
+        : undefined;
+
+  if (!rules) {
+    return { xml, sanitizedFields: 0 };
+  }
+
+  let updatedXml = xml;
+  let sanitizedFields = 0;
+
+  for (const rule of rules) {
+    const result = replaceTagValue(updatedXml, rule.tagName, rule.replacement);
+    updatedXml = result.xml;
+    sanitizedFields += result.replacements;
+  }
+
+  return { xml: updatedXml, sanitizedFields };
+}
+
+export function stripMediaReferencesFromRels(xml: string): string {
+  return xml.replace(
+    /<Relationship\b[^>]*\bTarget=(["'])([^"']+)\1[^>]*\/>/gi,
+    (full, _quote, target: string) => {
+      const normalizedTarget = target.toLowerCase().replace(/\\/g, '/');
+      if (normalizedTarget.startsWith('media/') || normalizedTarget.includes('/media/')) {
+        return '';
+      }
+      return full;
+    }
+  );
+}
+
+export function stripMediaMarkupFromWordXml(xml: string): string {
+  const MARKUP_PATTERNS = [
+    /<(?:[\w.-]+:)?drawing\b[\s\S]*?<\/(?:[\w.-]+:)?drawing>/g,
+    /<(?:[\w.-]+:)?pict\b[\s\S]*?<\/(?:[\w.-]+:)?pict>/g,
+    /<(?:[\w.-]+:)?object\b[\s\S]*?<\/(?:[\w.-]+:)?object>/g,
+    /<(?:[\w.-]+:)?imagedata\b[^>]*\/>/g,
+  ];
+
+  let updatedXml = xml;
+  for (const pattern of MARKUP_PATTERNS) {
+    updatedXml = updatedXml.replace(pattern, '');
+  }
+
+  return updatedXml;
+}
+
+export function replaceWordsKeepingLengths(
   value: string,
   generator: LoremWordGenerator
 ): { text: string; replacedWords: number } {
   let replacedWords = 0;
-  const text = value.replace(/[\p{L}\p{N}]+/gu, (word) => {
+  const text = value.replace(/\p{L}+/gu, (word) => {
     replacedWords += 1;
     const replacement = generator.next(word.length);
     return applyCasing(word, replacement);
@@ -171,7 +270,10 @@ function replaceWordsKeepingLengths(
   return { text, replacedWords };
 }
 
-function loremifyXml(xml: string, generator: LoremWordGenerator): { xml: string; replacedWords: number } {
+export function loremifyXml(
+  xml: string,
+  generator: LoremWordGenerator
+): { xml: string; replacedWords: number } {
   let updatedXml = xml;
   let replacedWords = 0;
 
@@ -193,11 +295,12 @@ function loremifyXml(xml: string, generator: LoremWordGenerator): { xml: string;
   return { xml: updatedXml, replacedWords };
 }
 
-function parseArgs(argv: string[]): CliOptions {
+export function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     help: false,
     inPlace: false,
     allXml: false,
+    stripMedia: false,
     suffix: '.lorem',
     inputs: [],
   };
@@ -217,6 +320,11 @@ function parseArgs(argv: string[]): CliOptions {
 
     if (arg === '--all-xml') {
       options.allXml = true;
+      continue;
+    }
+
+    if (arg === '--strip-media') {
+      options.stripMedia = true;
       continue;
     }
 
@@ -263,30 +371,75 @@ function getOutputPath(inputPath: string, options: CliOptions): string {
 
 async function loremifyDocxBuffer(
   buffer: Buffer,
-  options: Pick<CliOptions, 'allXml'>
+  options: Pick<CliOptions, 'allXml' | 'stripMedia'>
 ): Promise<{ output: Buffer; stats: FileStats }> {
   const zip = await JSZip.loadAsync(buffer);
   const generator = new LoremWordGenerator();
 
   let xmlFilesUpdated = 0;
   let wordsReplaced = 0;
+  let metadataFieldsSanitized = 0;
+  let mediaFilesRemoved = 0;
+
+  if (options.stripMedia) {
+    for (const [zipPath, zipFile] of Object.entries(zip.files)) {
+      if (!zipFile.dir && zipPath.toLowerCase().startsWith('word/media/')) {
+        zip.remove(zipPath);
+        mediaFilesRemoved += 1;
+      }
+    }
+  }
 
   for (const [zipPath, zipFile] of Object.entries(zip.files)) {
-    if (zipFile.dir || !zipPath.toLowerCase().endsWith('.xml')) {
-      continue;
-    }
+    const lower = zipPath.toLowerCase();
+    const isXml = lower.endsWith('.xml');
+    const isWordRels = /^word\/_rels\/.+\.rels$/.test(lower);
 
-    if (!shouldProcessXmlPart(zipPath, options.allXml)) {
+    if (zipFile.dir || (!isXml && !(options.stripMedia && isWordRels))) {
       continue;
     }
 
     const xml = await zipFile.async('text');
-    const result = loremifyXml(xml, generator);
-    wordsReplaced += result.replacedWords;
+    let updatedXml = xml;
+    let changed = false;
 
-    if (result.xml !== xml) {
+    if (isXml && shouldProcessXmlPart(zipPath, options.allXml)) {
+      const result = loremifyXml(updatedXml, generator);
+      updatedXml = result.xml;
+      wordsReplaced += result.replacedWords;
+      changed = changed || result.xml !== xml;
+    }
+
+    if (isXml) {
+      const metadataResult = sanitizeMetadataXml(zipPath, updatedXml);
+      if (metadataResult.sanitizedFields > 0) {
+        updatedXml = metadataResult.xml;
+        metadataFieldsSanitized += metadataResult.sanitizedFields;
+        changed = true;
+      }
+    }
+
+    if (options.stripMedia) {
+      if (lower.startsWith('word/') && lower.endsWith('.xml')) {
+        const withoutMarkup = stripMediaMarkupFromWordXml(updatedXml);
+        if (withoutMarkup !== updatedXml) {
+          updatedXml = withoutMarkup;
+          changed = true;
+        }
+      }
+
+      if (/^word\/_rels\/.+\.rels$/.test(lower)) {
+        const withoutMediaRelationships = stripMediaReferencesFromRels(updatedXml);
+        if (withoutMediaRelationships !== updatedXml) {
+          updatedXml = withoutMediaRelationships;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
       xmlFilesUpdated += 1;
-      zip.file(zipPath, result.xml, {
+      zip.file(zipPath, updatedXml, {
         compression: 'DEFLATE',
         compressionOptions: { level: 6 },
       });
@@ -301,7 +454,7 @@ async function loremifyDocxBuffer(
 
   return {
     output,
-    stats: { xmlFilesUpdated, wordsReplaced },
+    stats: { xmlFilesUpdated, wordsReplaced, mediaFilesRemoved, metadataFieldsSanitized },
   };
 }
 
@@ -342,6 +495,8 @@ async function processFile(inputPath: string, options: CliOptions): Promise<void
       `Output: ${outputPath}`,
       `Updated XML files: ${result.stats.xmlFilesUpdated}`,
       `Words replaced: ${result.stats.wordsReplaced}`,
+      `Metadata fields sanitized: ${result.stats.metadataFieldsSanitized}`,
+      `Media files removed: ${result.stats.mediaFilesRemoved}`,
       '',
     ].join('\n')
   );
@@ -368,8 +523,10 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`Error: ${message}`);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
  ## Summary
  I hope this helps so issue reporters can share reproducible files without exposing confidential
  text.

  ## What this PR changes
  - Adds a new CLI script: `scripts/loremify-docx.ts`
  - Adds a package script:
    - `bun run docx:loremify -- <file.docx>`
  - Adds contributor documentation in `CONTRIBUTING.md` showing how to sanitize files before attaching them to issues

  ## Behavior
  - Replaces human-readable DOCX run text with lorem-style text
  - Preserves document structure and formatting-critical layout containers (tables, nesting, headers/footers, styles,
  relationships)
  - Preserves per-word lengths so visual flow stays close to the source document
  - Defaults to safer story-part replacement (main document + headers/footers/notes/comments)
  - Supports `--all-xml` for advanced full-XML replacement when needed

  ## Usage
  ```bash
  bun run docx:loremify -- "path/to/file.docx"
  bun run docx:loremify -- "path/to/file.docx" --out-dir sanitized-docs