### PR TITLE
spec: monorepo extraction for framework-agnostic core

### DIFF
--- a/openspec/changes/extract-core-monorepo/.openspec.yaml
+++ b/openspec/changes/extract-core-monorepo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/extract-core-monorepo/design.md
+++ b/openspec/changes/extract-core-monorepo/design.md
@@ -1,0 +1,217 @@
+## Context
+
+The editor is currently a single npm package (`@eigenpal/docx-js-editor`) with ~80% framework-agnostic code and ~20% React UI. The codebase already has clean internal boundaries — separate entry points (`core.ts`, `headless.ts`, `react.ts`, `ui.ts`) and framework-agnostic directories (`src/docx/`, `src/types/`, `src/prosemirror/`, `src/layout-engine/`, `src/layout-painter/`, `src/layout-bridge/`). A community contributor wants to build a Vue wrapper, which requires the core to be importable without React dependencies.
+
+Current state:
+
+- Single `package.json`, single `tsup.config.ts` building 7 entry points
+- React is an optional peer dependency
+- Two files in `src/utils/` import `type CSSProperties from 'react'` (type-only)
+- `src/plugin-api/types.ts` imports `type ReactNode from 'react'` (type-only)
+- ProseMirror packages are direct dependencies
+- `@radix-ui/react-select` is a direct dependency (React-only)
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extract framework-agnostic core into `@eigenpal/docx-core` with zero React dependencies
+- Keep `@eigenpal/docx-js-editor` as the React UI package (preserves npm stats, no migration for existing users)
+- Use Bun workspaces for monorepo management (already using Bun as runtime)
+- Enable community Vue/Svelte wrappers that depend only on `@eigenpal/docx-core`
+- Maintain a single repo, single CI pipeline
+
+**Non-Goals:**
+
+- Building the Vue package (community contribution)
+- Splitting into more than 2 packages (core + react is sufficient; no separate layout/prosemirror packages)
+- Changing any public API signatures
+- Migrating build tool away from tsup
+
+## Decisions
+
+### 1. Two packages, not more
+
+**Decision:** Split into exactly `@eigenpal/docx-core` and `@eigenpal/docx-js-editor` (React).
+
+**Rationale:** More packages (separate layout, prosemirror, UI packages) adds versioning complexity without clear benefit. The Vue contributor needs one clean core dependency. Two packages is the minimum viable split.
+
+**Alternative considered:** 4+ packages (core, layout, prosemirror, react, ui). Rejected — too much coordination overhead for the current project size.
+
+### 2. Bun workspaces (not turborepo/nx/lerna)
+
+**Decision:** Use Bun's native workspaces feature.
+
+**Rationale:** Already using Bun as runtime. Bun workspaces are simple (`"workspaces"` field in root `package.json`) and require no additional tooling. Sufficient for 2 packages.
+
+**Alternative considered:** Turborepo for caching. Rejected — overkill for 2 packages, adds dependency.
+
+### 3. Keep existing package name for React
+
+**Decision:** `@eigenpal/docx-js-editor` stays as the React package name. No rename.
+
+**Rationale:** Preserves npm download stats, existing users don't need to migrate, no deprecation dance.
+
+### 4. What goes in core vs react
+
+**Core (`@eigenpal/docx-core`):**
+
+- `src/docx/` — DOCX parsing, serialization, XML handling
+- `src/types/` — document model types
+- `src/prosemirror/` — schema, extensions, plugins, commands, conversions
+- `src/layout-engine/` — pagination algorithm
+- `src/layout-painter/` — vanilla DOM rendering
+- `src/layout-bridge/` — hit-testing, position mapping
+- `src/core-plugins/` — plugin registry
+- `src/utils/` — all utilities (with React type leaks cleaned up)
+- `src/agent/` — DocumentAgent API
+- `src/mcp/` — MCP server tools
+- Entry points: `core.ts`, `headless.ts`
+
+**React (`@eigenpal/docx-js-editor`):**
+
+- `src/components/` — React UI components (toolbar, dialogs, pickers)
+- `src/hooks/` — React hooks
+- `src/plugin-api/` — PluginHost React component
+- `src/plugins/` — template plugin with React overlays
+- `src/paged-editor/` — PagedEditor, HiddenProseMirror, SelectionOverlay (React components)
+- `src/styles/` — CSS
+- Entry points: `index.ts`, `react.ts`, `ui.ts`
+
+**Rationale:** ProseMirror itself is framework-agnostic (vanilla JS library). The PM extensions, schema, and commands have zero React imports. Only the React wrappers (`HiddenProseMirror.tsx`, `PagedEditor.tsx`) need React. A Vue wrapper would create its own equivalents of these ~4 React components while reusing all the PM logic from core.
+
+### 5. Handle React type leaks
+
+**Decision:** Replace `type CSSProperties from 'react'` with a local type alias `Record<string, string | number>` or extract from `csstype` (which React itself uses internally).
+
+**Rationale:** These are type-only imports that don't affect runtime bundles, but they create a conceptual dependency that confuses the boundary. Clean them up for correctness.
+
+### 6. Internal cross-package imports
+
+**Decision:** React package imports from `@eigenpal/docx-core` (the npm package name), not relative paths.
+
+**Rationale:** Bun workspaces resolve workspace packages by name. This ensures the React package treats core as a proper dependency, matching what external consumers see.
+
+### 7. Build setup
+
+**Decision:** Each package has its own `tsup.config.ts` and `package.json`. Root `package.json` defines workspaces and shared scripts.
+
+**Rationale:** Per-package builds are independent, can be run in parallel, and each package controls its own entry points and externals.
+
+### 8. Cross-framework plugin abstraction
+
+**Decision:** Split the current `EditorPlugin` interface into a framework-agnostic core and framework-specific adapters.
+
+**Core interface (`@eigenpal/docx-core`):**
+
+```typescript
+interface EditorPluginCore<TState = any> {
+  id: string;
+  name: string;
+  proseMirrorPlugins?: ProseMirrorPlugin[]; // framework-agnostic
+  onStateChange?: (view: EditorView) => TState | undefined;
+  initialize?: (view: EditorView | null) => TState;
+  destroy?: () => void;
+  styles?: string;
+  panelConfig?: PanelConfig;
+}
+```
+
+**React adapter (`@eigenpal/docx-js-editor`):**
+
+```typescript
+interface ReactEditorPlugin<TState = any> extends EditorPluginCore<TState> {
+  Panel?: React.ComponentType<PluginPanelProps<TState>>;
+  renderOverlay?: (
+    context: RenderedDomContext,
+    state: TState,
+    view: EditorView | null
+  ) => ReactNode;
+}
+```
+
+**Vue adapter (`@eigenpal/docx-editor-vue`):**
+
+```typescript
+interface VueEditorPlugin<TState = any> extends EditorPluginCore<TState> {
+  Panel?: DefineComponent<PluginPanelProps<TState>>;
+  renderOverlay?: (context: RenderedDomContext, state: TState, view: EditorView | null) => VNode;
+}
+```
+
+**What moves where:**
+
+- `EditorPluginCore`, `PanelConfig`, `PluginPanelProps` (without ReactNode), `RenderedDomContext` → `@eigenpal/docx-core`
+- `PluginHost.tsx` stays in React package as `ReactPluginHost` — renders `Panel` as React components
+- Vue package builds its own `VuePluginHost` — renders `Panel` as Vue components
+- `CorePlugin` (headless command/MCP system) stays in core unchanged — already framework-agnostic
+
+**Plugin authoring pattern:**
+A plugin author writes the core logic once (PM plugins, state, styles), then provides a thin framework-specific UI:
+
+```typescript
+// Shared core logic (in a plugin package or inline)
+const templatePluginCore: EditorPluginCore<TemplateState> = {
+  id: 'template',
+  proseMirrorPlugins: [createTemplatePlugin()],
+  onStateChange: (view) => getTemplateState(view),
+  styles: templateCSS,
+  panelConfig: { position: 'right', defaultWidth: 280 },
+};
+
+// React version
+const templatePluginReact: ReactEditorPlugin<TemplateState> = {
+  ...templatePluginCore,
+  Panel: AnnotationPanel,           // React component
+  renderOverlay: (ctx, state) => <TemplateHighlightOverlay ... />,
+};
+
+// Vue version
+const templatePluginVue: VueEditorPlugin<TemplateState> = {
+  ...templatePluginCore,
+  Panel: VueAnnotationPanel,       // Vue component
+  renderOverlay: (ctx, state) => h(VueTemplateHighlightOverlay, ...),
+};
+```
+
+**Rationale:** The current `EditorPlugin` interface is tightly coupled to React via `Panel` (React.ComponentType) and `renderOverlay` (returns ReactNode). But the core logic — PM plugins, state management, event handling, CSS — is already framework-agnostic. Splitting the interface lets plugin authors share ~80% of their plugin code across frameworks.
+
+**Alternative considered:** A framework-agnostic rendering approach (e.g., plugins return vanilla DOM elements instead of React/Vue components). Rejected — this would sacrifice the DX of using each framework's component model for building panels and overlays. The thin adapter approach keeps the best of both worlds.
+
+### 9. Cross-framework E2E test reuse via Playwright projects
+
+**Decision:** Split tests into shared core tests and framework-specific UI tests. Use Playwright's `projects` config to run shared tests against both React and Vue apps on different ports.
+
+**Rationale:** The Playwright tests don't test React internals — they interact with the browser DOM (clicking, typing, checking rendered output). Since both React and Vue render the same core (same ProseMirror instance, same layout painter DOM output), ~60-70% of tests are reusable as-is. Only toolbar/dialog tests are framework-specific.
+
+**Structure:**
+
+```
+tests/
+  shared/        ← formatting, editing, rendering, file loading (run against both)
+  react/         ← toolbar, dialogs, pickers (React-specific)
+  vue/           ← Vue-specific UI tests (contributor adds these)
+
+playwright.config.ts:
+  projects:
+    - name: react,  baseURL: http://localhost:5173
+    - name: vue,    baseURL: http://localhost:5174
+
+examples/
+  vite/          ← React dev app (port 5173)
+  vue/           ← Vue dev app (port 5174, Vite + @vitejs/plugin-vue)
+```
+
+**Alternative considered:** Separate test suites per framework. Rejected — duplicates effort, core behavior should be tested identically.
+
+## Risks / Trade-offs
+
+**[Risk] Internal import churn** → Files that currently do `../docx/parser` will need `@eigenpal/docx-core` imports. Mitigation: batch find-and-replace, verify with typecheck.
+
+**[Risk] Circular dependencies between packages** → Core must not import from React package. Mitigation: the current code already respects this boundary (core modules don't import React components). Verify with a "no-import" lint rule.
+
+**[Risk] Dev experience regression** → Working across two packages can be slower. Mitigation: Bun workspaces auto-link local packages; `bun run dev` from root can start both.
+
+**[Risk] Test infrastructure split** → Playwright E2E tests need the full editor (core + react). Mitigation: E2E tests stay in a top-level `tests/` directory (or in the React package) and import both packages. Core gets its own unit tests.
+
+**[Trade-off] Two package releases instead of one** → Accepted. Core will change less frequently than React UI, so this is manageable.

--- a/openspec/changes/extract-core-monorepo/proposal.md
+++ b/openspec/changes/extract-core-monorepo/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The editor's core (DOCX parsing, ProseMirror schema/extensions/plugins, layout engine, document model) is ~80% of the codebase and already framework-agnostic, but it's bundled in a single package with React UI components. Users of other frameworks (Vue, Svelte, vanilla JS) must either ship React as a dependency or fork the entire project, losing upstream contributions. Extracting the core into a separate package enables a framework-agnostic ecosystem where community members can build wrappers (e.g., Vue) on top of the same core.
+
+## What Changes
+
+- **BREAKING**: Split the single `@eigenpal/docx-js-editor` package into a Bun workspaces monorepo with separate packages
+- New `@eigenpal/docx-core` package containing all framework-agnostic code: `src/docx/`, `src/types/`, `src/prosemirror/`, `src/layout-engine/`, `src/layout-painter/`, `src/layout-bridge/`, `src/core-plugins/`, `src/utils/` (non-React parts), `src/agent/`, `src/mcp/`
+- `@eigenpal/docx-js-editor` becomes a thin React UI package depending on `@eigenpal/docx-core`, containing: `src/components/`, `src/hooks/`, `src/plugin-api/`, `src/plugins/`, `src/paged-editor/`
+- Remove React type leaks from core code paths (e.g., `CSSProperties` imports in utils)
+- Split `EditorPlugin` interface into a framework-agnostic core (`EditorPluginCore` in `@eigenpal/docx-core`) and framework-specific adapters (`ReactEditorPlugin` in React package, `VueEditorPlugin` in Vue package)
+- Existing `@eigenpal/docx-js-editor` keeps its npm name and download stats — existing users continue using it as before
+- Shared build/test/lint configuration at monorepo root
+
+## Capabilities
+
+### New Capabilities
+
+- `monorepo-structure`: Bun workspaces monorepo with `packages/core/`, `packages/react/`, and `packages/vue/` (scaffold), shared tsconfig, build scripts, and dependency management
+- `core-package-api`: Public API surface for `@eigenpal/docx-core` — exports for DOCX parsing/serialization, ProseMirror schema/extensions/commands, layout engine, document model types, and headless editor creation
+- `cross-framework-plugins`: Framework-agnostic `EditorPluginCore` interface in core with framework-specific adapters (`ReactEditorPlugin`, `VueEditorPlugin`) so plugin logic (ProseMirror plugins, state, styles) is written once and UI rendering (panels, overlays) is provided per framework
+
+### Modified Capabilities
+
+## Impact
+
+- **Package structure**: Single package becomes monorepo with 3 packages (core, react, vue scaffold)
+- **npm**: New `@eigenpal/docx-core` package published; `@eigenpal/docx-js-editor` gains `@eigenpal/docx-core` as dependency; `@eigenpal/docx-editor-vue` scaffolded for community contribution
+- **Imports**: Internal imports between core and React code change to cross-package imports
+- **Build**: `tsup` config splits into per-package builds; CSS build stays in React package
+- **Tests**: Playwright E2E tests stay in React package (they test the full editor); unit tests for core logic move to core package
+- **CI**: Needs to build/test both packages
+- **Dependencies**: `@radix-ui/react-select`, React peer deps move to React package only; ProseMirror, jszip, xml-js, docxtemplater stay in core
+- **Downstream**: Vue/Svelte/vanilla consumers can depend on `@eigenpal/docx-core` directly with zero React overhead

--- a/openspec/changes/extract-core-monorepo/specs/core-package-api/spec.md
+++ b/openspec/changes/extract-core-monorepo/specs/core-package-api/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Core package exports DOCX parsing and serialization
+
+The `@eigenpal/docx-core` package SHALL export functions for parsing DOCX files into the document model and serializing the document model back to DOCX.
+
+#### Scenario: Parse a DOCX file
+
+- **WHEN** a consumer imports `parseDocx` from `@eigenpal/docx-core`
+- **AND** calls it with a DOCX file buffer
+- **THEN** it SHALL return a parsed `Document` object matching the existing API
+
+#### Scenario: Serialize a document to DOCX
+
+- **WHEN** a consumer imports `serializeDocx` from `@eigenpal/docx-core`
+- **AND** calls it with a `Document` object
+- **THEN** it SHALL return a DOCX file buffer matching the existing API
+
+### Requirement: Core package exports document model types
+
+The `@eigenpal/docx-core` package SHALL export all document model types needed to work with parsed documents.
+
+#### Scenario: Import document types
+
+- **WHEN** a consumer imports types from `@eigenpal/docx-core`
+- **THEN** all types from `src/types/` SHALL be available (Paragraph, Run, Table, Style, Color, etc.)
+
+### Requirement: Core package exports ProseMirror schema and extensions
+
+The `@eigenpal/docx-core` package SHALL export the ProseMirror schema, extension system, and all extensions for building an editor instance.
+
+#### Scenario: Create a ProseMirror editor from core
+
+- **WHEN** a consumer imports `createStarterKit` and `ExtensionManager` from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to build a ProseMirror schema and create an `EditorState`
+- **AND** all existing extensions (bold, italic, table, list, etc.) SHALL be available
+
+#### Scenario: Convert between document model and ProseMirror
+
+- **WHEN** a consumer imports `toProseDoc` and `fromProseDoc` from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to convert between the document model and ProseMirror document format
+
+### Requirement: Core package exports layout engine
+
+The `@eigenpal/docx-core` package SHALL export the layout engine for paginating documents and the layout painter for rendering pages to DOM.
+
+#### Scenario: Use layout engine for pagination
+
+- **WHEN** a consumer imports layout engine functions from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to paginate a ProseMirror document into pages
+
+#### Scenario: Use layout painter for DOM rendering
+
+- **WHEN** a consumer imports layout painter functions from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to render pages as vanilla DOM elements (no React required)
+
+### Requirement: Core package exports headless API
+
+The `@eigenpal/docx-core` package SHALL export the `DocumentAgent` class for headless document manipulation without a browser.
+
+#### Scenario: Use DocumentAgent headlessly
+
+- **WHEN** a consumer imports `DocumentAgent` from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to programmatically manipulate DOCX files in Node.js without React or DOM dependencies
+
+### Requirement: Core package exports utility functions
+
+The `@eigenpal/docx-core` package SHALL export utility functions for color resolution, unit conversion, font loading, template processing, and variable detection.
+
+#### Scenario: Resolve theme colors
+
+- **WHEN** a consumer imports color resolution utilities from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to resolve theme colors to hex values
+
+#### Scenario: Process docxtemplater templates
+
+- **WHEN** a consumer imports template processing utilities from `@eigenpal/docx-core`
+- **THEN** they SHALL be able to detect variables and process templates
+
+### Requirement: React package re-exports core
+
+The `@eigenpal/docx-js-editor` main entry point SHALL re-export everything from `@eigenpal/docx-core` for backwards compatibility.
+
+#### Scenario: Existing imports continue working
+
+- **WHEN** an existing user imports from `@eigenpal/docx-js-editor`
+- **THEN** all previously available exports SHALL still be available
+- **AND** no import paths SHALL break
+
+#### Scenario: Subpath exports preserved
+
+- **WHEN** an existing user imports from `@eigenpal/docx-js-editor/core` or `@eigenpal/docx-js-editor/headless`
+- **THEN** those imports SHALL continue to work (re-exporting from `@eigenpal/docx-core`)

--- a/openspec/changes/extract-core-monorepo/specs/cross-framework-plugins/spec.md
+++ b/openspec/changes/extract-core-monorepo/specs/cross-framework-plugins/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Framework-agnostic EditorPluginCore interface in core
+
+The `@eigenpal/docx-core` package SHALL export an `EditorPluginCore` interface containing all framework-agnostic plugin fields: `id`, `name`, `proseMirrorPlugins`, `onStateChange`, `initialize`, `destroy`, `styles`, and `panelConfig`.
+
+#### Scenario: Define a plugin with core logic only
+
+- **WHEN** a plugin author imports `EditorPluginCore` from `@eigenpal/docx-core`
+- **AND** creates a plugin with `id`, `proseMirrorPlugins`, `onStateChange`, and `styles`
+- **THEN** the plugin definition SHALL compile without React or Vue as dependencies
+
+#### Scenario: EditorPluginCore has no framework types
+
+- **WHEN** inspecting the `EditorPluginCore` interface in `@eigenpal/docx-core`
+- **THEN** it SHALL NOT reference `ReactNode`, `React.ComponentType`, `DefineComponent`, `VNode`, or any framework-specific types
+
+### Requirement: PluginPanelProps exported from core without framework types
+
+The `@eigenpal/docx-core` package SHALL export a `PluginPanelProps` interface containing the framework-agnostic fields: `editorView`, `doc`, `scrollToPosition`, `selectRange`, `pluginState`, `panelWidth`, and `renderedDomContext`.
+
+#### Scenario: PluginPanelProps usable by any framework
+
+- **WHEN** a framework adapter imports `PluginPanelProps` from `@eigenpal/docx-core`
+- **THEN** it SHALL be able to extend or use it as props for its own component type
+- **AND** `PluginPanelProps` SHALL NOT contain any framework-specific fields
+
+### Requirement: RenderedDomContext exported from core
+
+The `@eigenpal/docx-core` package SHALL export the `RenderedDomContext` interface and its implementation, as it uses only vanilla DOM APIs.
+
+#### Scenario: RenderedDomContext available to plugin overlays
+
+- **WHEN** a plugin overlay (in any framework) needs to map ProseMirror positions to pixel coordinates
+- **THEN** it SHALL import `RenderedDomContext` from `@eigenpal/docx-core`
+- **AND** use `getCoordinatesForPosition()`, `getRectsForRange()`, and `findElementsForRange()` without any framework dependency
+
+### Requirement: PanelConfig exported from core
+
+The `@eigenpal/docx-core` package SHALL export the `PanelConfig` type (position, default width, collapsible settings).
+
+#### Scenario: Plugin specifies panel position
+
+- **WHEN** a plugin sets `panelConfig: { position: 'right', defaultWidth: 280 }`
+- **THEN** both React and Vue PluginHosts SHALL interpret this identically
+
+### Requirement: ReactEditorPlugin extends EditorPluginCore
+
+The `@eigenpal/docx-js-editor` package SHALL export a `ReactEditorPlugin` interface that extends `EditorPluginCore` with React-specific fields: `Panel` (React.ComponentType) and `renderOverlay` (returns ReactNode).
+
+#### Scenario: Existing React plugins remain compatible
+
+- **WHEN** the existing template plugin is updated to use `ReactEditorPlugin`
+- **THEN** it SHALL compile and function identically to the current `EditorPlugin` interface
+- **AND** no behavioral changes SHALL occur
+
+#### Scenario: React plugin spreads core into adapter
+
+- **WHEN** a plugin author creates an `EditorPluginCore` object and spreads it into a `ReactEditorPlugin`
+- **THEN** the result SHALL be a valid `ReactEditorPlugin` with both core logic and React UI
+
+### Requirement: ReactPluginHost renders ReactEditorPlugin panels and overlays
+
+The `@eigenpal/docx-js-editor` package SHALL contain a `PluginHost` (or `ReactPluginHost`) component that accepts `ReactEditorPlugin[]` and renders panels/overlays using React.
+
+#### Scenario: PluginHost manages plugin lifecycle
+
+- **WHEN** `PluginHost` receives an array of `ReactEditorPlugin` instances
+- **THEN** it SHALL call `initialize()` on mount, `onStateChange()` on editor changes, and `destroy()` on unmount
+- **AND** it SHALL render `Panel` components in configured positions
+- **AND** it SHALL render `renderOverlay()` output in the viewport overlay container
+
+### Requirement: VueEditorPlugin interface scaffolded in Vue package
+
+The `@eigenpal/docx-editor-vue` package SHALL export a `VueEditorPlugin` interface that extends `EditorPluginCore` with Vue-specific fields for panel and overlay rendering.
+
+#### Scenario: Vue plugin interface mirrors React adapter pattern
+
+- **WHEN** inspecting `VueEditorPlugin` in `@eigenpal/docx-editor-vue`
+- **THEN** it SHALL extend `EditorPluginCore` from `@eigenpal/docx-core`
+- **AND** it SHALL define `Panel` using Vue's `DefineComponent` (or equivalent)
+- **AND** it SHALL define `renderOverlay` returning Vue's `VNode` (or equivalent)
+
+### Requirement: CorePlugin system unchanged
+
+The existing `CorePlugin` interface and `PluginRegistry` in `@eigenpal/docx-core` SHALL remain unchanged, as they are already framework-agnostic.
+
+#### Scenario: CorePlugin continues to work headlessly
+
+- **WHEN** a `CorePlugin` is registered with command handlers and MCP tools
+- **THEN** it SHALL function identically to the current implementation
+- **AND** no changes to the `CorePlugin` interface SHALL be required

--- a/openspec/changes/extract-core-monorepo/specs/monorepo-structure/spec.md
+++ b/openspec/changes/extract-core-monorepo/specs/monorepo-structure/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: Bun workspaces monorepo structure
+
+The repository SHALL be organized as a Bun workspaces monorepo with a root `package.json` containing a `"workspaces"` field pointing to `packages/*`.
+
+#### Scenario: Root package.json defines workspaces
+
+- **WHEN** a developer clones the repository
+- **THEN** the root `package.json` SHALL contain `"workspaces": ["packages/*"]`
+- **AND** the root `package.json` SHALL have `"private": true`
+- **AND** running `bun install` from the root SHALL install dependencies for all packages
+
+### Requirement: Core package directory structure
+
+The `packages/core/` directory SHALL contain all framework-agnostic source code with its own `package.json` named `@eigenpal/docx-core`.
+
+#### Scenario: Core package contains framework-agnostic modules
+
+- **WHEN** inspecting `packages/core/src/`
+- **THEN** it SHALL contain the directories: `docx/`, `types/`, `prosemirror/`, `layout-engine/`, `layout-painter/`, `layout-bridge/`, `core-plugins/`, `utils/`, `agent/`, `mcp/`
+- **AND** it SHALL contain entry points: `core.ts`, `headless.ts`
+- **AND** no file in the package SHALL have a runtime import of `react` or `react-dom`
+
+#### Scenario: Core package.json declares correct dependencies
+
+- **WHEN** inspecting `packages/core/package.json`
+- **THEN** dependencies SHALL include: prosemirror packages, jszip, pizzip, xml-js, docxtemplater, clsx
+- **AND** `react` and `react-dom` SHALL NOT appear in dependencies or peerDependencies
+
+### Requirement: React package directory structure
+
+The `packages/react/` directory SHALL contain all React-dependent source code with its own `package.json` named `@eigenpal/docx-js-editor`.
+
+#### Scenario: React package contains UI modules
+
+- **WHEN** inspecting `packages/react/src/`
+- **THEN** it SHALL contain the directories: `components/`, `hooks/`, `plugin-api/`, `plugins/`, `paged-editor/`, `styles/`
+- **AND** it SHALL contain entry points: `index.ts`, `react.ts`, `ui.ts`
+
+#### Scenario: React package depends on core
+
+- **WHEN** inspecting `packages/react/package.json`
+- **THEN** `@eigenpal/docx-core` SHALL be listed in dependencies
+- **AND** `react` and `react-dom` SHALL be listed as peerDependencies
+- **AND** `@radix-ui/react-select` SHALL be listed in dependencies
+
+### Requirement: Each package has its own build configuration
+
+Each package SHALL have its own `tsup.config.ts` producing independent build outputs.
+
+#### Scenario: Core package builds independently
+
+- **WHEN** running `bun run build` in `packages/core/`
+- **THEN** it SHALL produce `dist/` with CJS and ESM outputs and type declarations
+- **AND** the build SHALL succeed without React installed
+
+#### Scenario: React package builds independently
+
+- **WHEN** running `bun run build` in `packages/react/`
+- **THEN** it SHALL produce `dist/` with CJS and ESM outputs, type declarations, and `styles.css`
+- **AND** it SHALL externalize `@eigenpal/docx-core` (not bundle it)
+
+### Requirement: Shared development scripts at root
+
+The root `package.json` SHALL provide convenience scripts that operate across all packages.
+
+#### Scenario: Root scripts orchestrate workspaces
+
+- **WHEN** running `bun run build` from the root
+- **THEN** it SHALL build core first, then react (respecting dependency order)
+
+#### Scenario: Typecheck runs across all packages
+
+- **WHEN** running `bun run typecheck` from the root
+- **THEN** it SHALL typecheck all packages
+
+### Requirement: Tests work across the monorepo
+
+Playwright E2E tests SHALL remain functional and test the full integrated editor.
+
+#### Scenario: E2E tests use both packages
+
+- **WHEN** running `npx playwright test` from the root (or a tests directory)
+- **THEN** tests SHALL import from both `@eigenpal/docx-core` and `@eigenpal/docx-js-editor`
+- **AND** all existing tests SHALL pass without modification to test logic
+
+### Requirement: Cross-framework E2E test reuse
+
+Core editor behavior tests (editing, formatting, rendering, file loading) SHALL be reusable across framework packages via Playwright projects parameterized by base URL.
+
+#### Scenario: Playwright config defines per-framework projects
+
+- **WHEN** inspecting `playwright.config.ts`
+- **THEN** it SHALL define a `react` project with `baseURL` pointing to the React example app (e.g., `http://localhost:5173`)
+- **AND** it SHALL define a `vue` project with `baseURL` pointing to the Vue example app (e.g., `http://localhost:5174`)
+
+#### Scenario: Core editing tests run against both frameworks
+
+- **WHEN** running `npx playwright test --project=react`
+- **THEN** shared core tests (editing, formatting, undo/redo, rendering, file loading) SHALL run against the React app
+- **WHEN** running `npx playwright test --project=vue`
+- **THEN** the same shared core tests SHALL run against the Vue app
+- **AND** results SHALL be equivalent for both frameworks
+
+#### Scenario: Framework-specific tests are scoped
+
+- **WHEN** a test file tests React-specific UI (toolbar, dialogs, pickers)
+- **THEN** it SHALL only run under the `react` project
+- **WHEN** a test file tests Vue-specific UI
+- **THEN** it SHALL only run under the `vue` project
+
+### Requirement: Vue example app for E2E testing
+
+An `examples/vue/` directory SHALL contain a minimal Vite + Vue app that mounts the Vue editor, serving as the test target for the `vue` Playwright project.
+
+#### Scenario: Vue example app runs with Vite
+
+- **WHEN** running `bun run dev` in `examples/vue/`
+- **THEN** it SHALL start a Vite dev server with `@vitejs/plugin-vue`
+- **AND** the app SHALL render a functional DOCX editor using `@eigenpal/docx-editor-vue` and `@eigenpal/docx-core`
+
+#### Scenario: Vue example app serves on a distinct port
+
+- **WHEN** the Vue example app is running
+- **THEN** it SHALL serve on a port different from the React example app (e.g., `5174` vs `5173`)
+
+### Requirement: Vue package scaffold
+
+The `packages/vue/` directory SHALL contain an empty scaffolded package named `@eigenpal/docx-editor-vue` with a dependency on `@eigenpal/docx-core`, ready for community contribution.
+
+#### Scenario: Vue package has minimal package.json
+
+- **WHEN** inspecting `packages/vue/package.json`
+- **THEN** it SHALL have name `@eigenpal/docx-editor-vue`
+- **AND** `@eigenpal/docx-core` SHALL be listed in dependencies
+- **AND** `vue` SHALL be listed in peerDependencies
+- **AND** `react` and `react-dom` SHALL NOT appear in dependencies or peerDependencies
+
+#### Scenario: Vue package has a placeholder entry point
+
+- **WHEN** inspecting `packages/vue/src/index.ts`
+- **THEN** it SHALL exist with a minimal export (e.g., empty or a version constant)
+- **AND** it SHALL contain a comment indicating the package is ready for community contribution
+
+### Requirement: Zero React type leaks in core
+
+The core package SHALL have no imports (including type-only) from `react` or `react-dom`.
+
+#### Scenario: CSSProperties type replaced
+
+- **WHEN** inspecting `utils/formatToStyle.ts` and `utils/selectionHighlight.ts` in core
+- **THEN** they SHALL use a local CSS properties type (e.g., `Record<string, string | number>`) instead of importing from React
+
+#### Scenario: Plugin types are framework-agnostic in core
+
+- **WHEN** inspecting plugin-related types in core
+- **THEN** they SHALL NOT reference `ReactNode` or any React types

--- a/openspec/changes/extract-core-monorepo/tasks.md
+++ b/openspec/changes/extract-core-monorepo/tasks.md
@@ -1,0 +1,89 @@
+## 1. Monorepo Scaffold
+
+- [ ] 1.1 Create `packages/core/` and `packages/react/` directories
+- [ ] 1.2 Add `"workspaces": ["packages/*"]` and `"private": true` to root `package.json`
+- [ ] 1.3 Create `packages/core/package.json` with name `@eigenpal/docx-core`, dependencies (prosemirror-\*, jszip, pizzip, xml-js, docxtemplater, clsx), and exports config
+- [ ] 1.4 Create `packages/react/package.json` with name `@eigenpal/docx-js-editor`, dependency on `@eigenpal/docx-core`, peerDependencies (react, react-dom), and `@radix-ui/react-select`
+- [ ] 1.5 Create `packages/vue/package.json` with name `@eigenpal/docx-editor-vue`, dependency on `@eigenpal/docx-core`, peerDependency on `vue`, and a placeholder `src/index.ts`
+- [ ] 1.6 Create `packages/core/tsconfig.json`, `packages/react/tsconfig.json`, and `packages/vue/tsconfig.json` extending a shared root tsconfig
+
+## 2. Move Source Files to Core Package
+
+- [ ] 2.1 Move `src/docx/` → `packages/core/src/docx/`
+- [ ] 2.2 Move `src/types/` → `packages/core/src/types/`
+- [ ] 2.3 Move `src/prosemirror/` → `packages/core/src/prosemirror/`
+- [ ] 2.4 Move `src/layout-engine/` → `packages/core/src/layout-engine/`
+- [ ] 2.5 Move `src/layout-painter/` → `packages/core/src/layout-painter/`
+- [ ] 2.6 Move `src/layout-bridge/` → `packages/core/src/layout-bridge/`
+- [ ] 2.7 Move `src/core-plugins/` → `packages/core/src/core-plugins/`
+- [ ] 2.8 Move `src/utils/` → `packages/core/src/utils/`
+- [ ] 2.9 Move `src/agent/` → `packages/core/src/agent/`
+- [ ] 2.10 Move `src/mcp/` → `packages/core/src/mcp/`
+- [ ] 2.11 Move `src/core.ts` and `src/headless.ts` → `packages/core/src/`
+
+## 3. Move Source Files to React Package
+
+- [ ] 3.1 Move `src/components/` → `packages/react/src/components/`
+- [ ] 3.2 Move `src/hooks/` → `packages/react/src/hooks/`
+- [ ] 3.3 Move `src/plugin-api/` → `packages/react/src/plugin-api/`
+- [ ] 3.4 Move `src/plugins/` → `packages/react/src/plugins/`
+- [ ] 3.5 Move `src/paged-editor/` → `packages/react/src/paged-editor/`
+- [ ] 3.6 Move `src/styles/` → `packages/react/src/styles/`
+- [ ] 3.7 Move `src/index.ts`, `src/react.ts`, `src/ui.ts`, `src/renderAsync.ts` → `packages/react/src/`
+- [ ] 3.8 Move `src/lib/` → `packages/react/src/lib/` (if React-specific) or `packages/core/src/lib/`
+
+## 4. Clean Up React Type Leaks in Core
+
+- [ ] 4.1 Replace `type CSSProperties from 'react'` in `utils/formatToStyle.ts` with a local type alias
+- [ ] 4.2 Replace `type CSSProperties from 'react'` in `utils/selectionHighlight.ts` with a local type alias
+- [ ] 4.3 Verify no remaining `react` or `react-dom` imports in `packages/core/` (use grep)
+
+## 5. Cross-Framework Plugin Abstraction
+
+- [ ] 5.1 Create `EditorPluginCore` interface in `packages/core/src/plugin-api/types.ts` with framework-agnostic fields only (`id`, `name`, `proseMirrorPlugins`, `onStateChange`, `initialize`, `destroy`, `styles`, `panelConfig`)
+- [ ] 5.2 Move `PluginPanelProps` (without `ReactNode` fields), `PanelConfig`, and `RenderedDomContext` to `packages/core/src/plugin-api/`
+- [ ] 5.3 Export `EditorPluginCore`, `PluginPanelProps`, `PanelConfig`, `RenderedDomContext` from `@eigenpal/docx-core`
+- [ ] 5.4 Create `ReactEditorPlugin` interface in `packages/react/src/plugin-api/types.ts` extending `EditorPluginCore` with `Panel` (React.ComponentType) and `renderOverlay` (returns ReactNode)
+- [ ] 5.5 Update `PluginHost.tsx` in React package to accept `ReactEditorPlugin[]` instead of `EditorPlugin[]`
+- [ ] 5.6 Update existing template plugin (`packages/react/src/plugins/template/`) to use `ReactEditorPlugin` — verify no behavioral changes
+- [ ] 5.7 Scaffold `VueEditorPlugin` interface in `packages/vue/src/plugin-api/types.ts` extending `EditorPluginCore` with Vue-specific `Panel` and `renderOverlay` types
+- [ ] 5.8 Export `ReactEditorPlugin` from `@eigenpal/docx-js-editor` and `VueEditorPlugin` from `@eigenpal/docx-editor-vue`
+
+## 6. Update Internal Imports
+
+- [ ] 6.1 Update all imports in `packages/react/` that reference core modules to use `@eigenpal/docx-core` instead of relative paths
+- [ ] 6.2 Update `packages/react/src/index.ts` to re-export everything from `@eigenpal/docx-core` for backwards compatibility
+- [ ] 6.3 Update `packages/react/src/react.ts` and `src/ui.ts` entry points for new paths
+- [ ] 6.4 Verify all internal imports in `packages/core/` use relative paths within the package
+
+## 7. Build Configuration
+
+- [ ] 7.1 Create `packages/core/tsup.config.ts` with entry points (`core.ts`, `headless.ts`) and externals
+- [ ] 7.2 Create `packages/react/tsup.config.ts` with entry points (`index.ts`, `react.ts`, `ui.ts`) externalizing `@eigenpal/docx-core`
+- [ ] 7.3 Move CSS build (`tailwindcss` command) to `packages/react/` build script
+- [ ] 7.4 Add root-level `build` script that builds core first, then react
+- [ ] 7.5 Add root-level `typecheck` script that typechecks all packages
+- [ ] 7.6 Update or remove the old root `tsup.config.ts`
+
+## 8. Test Infrastructure
+
+- [ ] 8.1 Ensure Playwright config resolves imports from both workspace packages
+- [ ] 8.2 Update Vite dev server config (`examples/vite/vite.config.ts`) to work with workspace packages
+- [ ] 8.3 Run `bun run typecheck` — fix any type errors from the restructuring
+- [ ] 8.4 Run targeted Playwright tests (`formatting.spec.ts`, `demo-docx.spec.ts`) to verify no regressions
+- [ ] 8.5 Run full test suite as final validation
+
+## 9. Cross-Framework E2E Test Reuse
+
+- [ ] 9.1 Separate test files into shared core tests (editing, formatting, rendering, file loading) and React-specific UI tests (toolbar, dialogs, pickers) — e.g., `tests/shared/` vs `tests/react/`
+- [ ] 9.2 Add `react` and `vue` projects to `playwright.config.ts`, each with its own `baseURL` (`localhost:5173` for React, `localhost:5174` for Vue)
+- [ ] 9.3 Configure shared tests to run under both projects; React-specific UI tests to run only under `react` project
+- [ ] 9.4 Create `examples/vue/` with a minimal Vite + Vue app (`@vitejs/plugin-vue`) that mounts the Vue editor on port 5174
+- [ ] 9.5 Verify shared tests pass against React app (`--project=react`)
+
+## 10. Backwards Compatibility Verification
+
+- [ ] 10.1 Verify `@eigenpal/docx-js-editor` main export includes all previously exported symbols
+- [ ] 10.2 Verify subpath exports (`/core`, `/headless`, `/react`, `/ui`, `/core-plugins`, `/mcp`) still work from the React package
+- [ ] 10.3 Verify `@eigenpal/docx-core` can be imported and used without React installed
+- [ ] 10.4 Update root README with new monorepo structure and usage instructions for core package

--- a/openspec/changes/extract-framework-agnostic-managers/.openspec.yaml
+++ b/openspec/changes/extract-framework-agnostic-managers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/extract-framework-agnostic-managers/design.md
+++ b/openspec/changes/extract-framework-agnostic-managers/design.md
@@ -1,0 +1,160 @@
+## Context
+
+This change follows `extract-core-monorepo`, which splits the codebase into `@eigenpal/docx-core` and `@eigenpal/docx-js-editor` (React). After that split, the package boundary is clean but the React package still contains ~50% framework-agnostic business logic embedded in React components and hooks. Specifically:
+
+- `PagedEditor.tsx` (2080 lines) — coordinates PM state, layout engine, layout painter, selection overlays, column resizing, image interaction. Uses 50+ `useRef`/`useState`.
+- `DocxEditor.tsx` (1400 lines) — manages document parsing, font loading, zoom, dialog state, extension manager, agent commands. Orchestrates everything.
+- `useClipboard` — DOM selection traversal, formatting extraction, clipboard read/write wrapped in React hook
+- `useAutoSave` — localStorage persistence with debounce wrapped in React hook
+- `useTableSelection` — multi-cell selection state machine wrapped in React hook
+- `PluginHost.tsx` — plugin state tracking, dispatch wrapping, CSS injection, DOM event listening
+- `renderAsync.ts` — imperative mount via `React.createRoot()`
+- `ErrorBoundary.tsx` — error capture via `componentDidCatch` + React context
+
+A Vue contributor would need to reimplement all of this logic. The goal is to extract the state machines and coordination logic into framework-agnostic classes in `@eigenpal/docx-core`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extract framework-agnostic state machines and coordination logic from React components into plain TypeScript classes in `@eigenpal/docx-core`
+- React components become thin wrappers (~50-70% line reduction) that subscribe to manager state and render
+- Vue contributor can build components by wrapping the same managers in Vue composables
+- Manager classes are independently unit-testable without DOM or React
+- Zero behavioral changes — pure internal refactor
+
+**Non-Goals:**
+
+- Rewriting PagedEditor or DocxEditor from scratch (incremental extraction)
+- Building the Vue composables (community contribution)
+- Changing any public API of `@eigenpal/docx-js-editor`
+- Extracting visual rendering logic (layout painter is already framework-agnostic)
+- Optimizing performance (preserve current behavior exactly)
+
+## Decisions
+
+### 1. Event-emitter pattern for manager→UI communication
+
+**Decision:** Manager classes use a simple typed event emitter (or callback registration) pattern to notify UI of state changes. No framework-specific reactivity.
+
+```typescript
+class LayoutCoordinator {
+  private listeners = new Set<() => void>();
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // React: useSyncExternalStore(coordinator.subscribe, coordinator.getSnapshot)
+  // Vue: watchEffect(() => { coordinator.subscribe(triggerRef) })
+}
+```
+
+**Rationale:** React 18's `useSyncExternalStore` is designed exactly for this — subscribing React to external state stores. Vue's `watchEffect` + manual trigger achieves the same. This is the standard pattern used by Zustand, Redux, and other framework-agnostic state libraries.
+
+**Alternative considered:** Making managers observable with Proxy/getter interception. Rejected — adds complexity, harder to debug, and both React and Vue have well-established patterns for subscribing to external stores.
+
+### 2. Incremental extraction, not big-bang rewrite
+
+**Decision:** Extract one manager at a time, run E2E tests after each extraction, commit when green.
+
+**Order of extraction (lowest risk first):**
+
+1. `AutoSaveManager` — simplest, isolated localStorage logic
+2. `TableSelectionManager` — self-contained state machine
+3. `ClipboardManager` — DOM logic, no layout dependencies
+4. `ErrorManager` — replaces React context with pub/sub
+5. `PluginLifecycleManager` — plugin state + dispatch wrapping
+6. `LayoutCoordinator` — biggest, most complex (PagedEditor core)
+7. `EditorCoordinator` — biggest, most complex (DocxEditor core)
+
+**Rationale:** Extracting in risk order lets us validate the pattern on simple cases before tackling the 2000-line components. Each step is independently shippable.
+
+**Alternative considered:** Extract everything at once. Rejected — too risky for components this large; a single mistake would be hard to bisect.
+
+### 3. Managers own state, components subscribe
+
+**Decision:** Each manager class holds its own state as plain properties. Framework components read from the manager (not copy into local state).
+
+```typescript
+// Manager owns the state
+class LayoutCoordinator {
+  layout: Layout | null = null;
+  selectionRects: SelectionRect[] = [];
+  caretPosition: CaretPosition | null = null;
+
+  getSnapshot() {
+    return { layout: this.layout, selectionRects: this.selectionRects, ... };
+  }
+}
+
+// React component subscribes
+function PagedEditor({ coordinator }) {
+  const state = useSyncExternalStore(
+    coordinator.subscribe,
+    coordinator.getSnapshot
+  );
+  // render using state
+}
+```
+
+**Rationale:** Avoids state duplication (manager + component both holding layout). Single source of truth. The `getSnapshot` pattern works with both `useSyncExternalStore` (React) and manual subscription (Vue).
+
+**Alternative considered:** Managers emit events with payloads, components store in local state. Rejected — leads to stale state bugs and sync issues.
+
+### 4. Keep managers in `@eigenpal/docx-core` as plain classes
+
+**Decision:** All manager/coordinator classes live in `packages/core/src/managers/` and are exported from `@eigenpal/docx-core`.
+
+**Rationale:** They have zero framework dependencies (pure TS + DOM APIs). Putting them in core means both React and Vue packages can import them directly.
+
+### 5. renderAsync becomes a framework-agnostic interface
+
+**Decision:** Define `EditorHandle` interface in core. Each framework provides its own `renderAsync` implementation.
+
+```typescript
+// Core
+interface EditorHandle {
+  save(): Promise<Blob>;
+  getDocument(): Document;
+  focus(): void;
+  destroy(): void;
+}
+
+// React: renderAsync(input, container, options) → Promise<EditorHandle>
+// Vue: renderAsyncVue(input, container, options) → Promise<EditorHandle>
+```
+
+**Rationale:** The handle interface is what consumers actually use. The mounting mechanism (createRoot vs createApp) is an implementation detail.
+
+### 6. ErrorManager replaces React ErrorBoundary + Context
+
+**Decision:** Replace the React-specific error capture pattern with a framework-agnostic `ErrorManager` class using pub/sub.
+
+```typescript
+class ErrorManager {
+  private notifications: ErrorNotification[] = [];
+  private listeners = new Set<(notifications: ErrorNotification[]) => void>();
+
+  showError(message: string, options?: ErrorOptions) { ... }
+  dismiss(id: string) { ... }
+  subscribe(listener) { ... }
+}
+```
+
+**Rationale:** `componentDidCatch` only catches render errors. The current error system also handles async errors via context. A pub/sub manager handles both cases and works with any framework.
+
+## Risks / Trade-offs
+
+**[Risk] PagedEditor extraction breaks subtle timing** → The current `useEffect` ordering in PagedEditor is load-bearing (layout must compute before selection overlay renders). Mitigation: LayoutCoordinator must preserve the same sequencing internally. Validate with E2E tests after extraction.
+
+**[Risk] Performance regression from subscription overhead** → Adding subscribe/notify between manager and component adds a layer. Mitigation: `useSyncExternalStore` is optimized for this. Benchmark before/after on large documents.
+
+**[Risk] Ref-based imperative APIs break** → PagedEditor exposes imperative methods via `forwardRef` + `useImperativeHandle`. Mitigation: These methods delegate to the coordinator, which the ref can still expose.
+
+**[Risk] Scope creep** → Extracting managers may reveal more tightly-coupled patterns. Mitigation: Strict incremental approach — extract, test, commit. Stop if a manager can't be cleanly extracted.
+
+**[Trade-off] More files, more indirection** → Components become simpler but there are now separate manager classes. Accepted — the reduction in component complexity and enabling Vue outweighs the extra files.
+
+**[Trade-off] `useSyncExternalStore` requires React 18+** → Already the minimum supported version. No impact.

--- a/openspec/changes/extract-framework-agnostic-managers/proposal.md
+++ b/openspec/changes/extract-framework-agnostic-managers/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+After the monorepo extraction (`extract-core-monorepo`), the package boundary is clean but ~50% of the editor's business logic remains trapped inside React components and hooks. `PagedEditor.tsx` (2080 lines), `DocxEditor.tsx` (1400 lines), and hooks like `useClipboard`, `useAutoSave`, `useTableSelection` all contain framework-agnostic state machines and coordination logic wrapped in React's `useState`/`useRef`/`useEffect`. A Vue contributor building `@eigenpal/docx-editor-vue` would need to reverse-engineer and reimplement all of this logic, which defeats the purpose of the core extraction.
+
+## What Changes
+
+- Extract `LayoutCoordinator` class from `PagedEditor.tsx` — manages layout pipeline caching, selection state, image interaction, column resizing, and the PM↔layout↔painter synchronization loop
+- Extract `EditorCoordinator` class from `DocxEditor.tsx` — manages document lifecycle, zoom, font loading, extension manager initialization, dialog state, and agent command execution
+- Extract `ClipboardManager` class from `useClipboard` hook — clipboard read/write, DOM selection traversal, formatting extraction
+- Extract `AutoSaveManager` class from `useAutoSave` hook — localStorage persistence, debounced save, restore logic
+- Extract `TableSelectionManager` class from `useTableSelection` hook — multi-cell selection state machine, data attribute queries
+- Extract `RenderAsync` interface from `renderAsync.ts` — framework-agnostic contract for imperatively mounting an editor into a DOM element
+- Extract `ErrorManager` class — error notification state, replacing React's `componentDidCatch` + context pattern with a pub/sub system
+- Extract `PluginLifecycleManager` from `PluginHost.tsx` — plugin state tracking, dispatch wrapping, CSS injection, event listening (separate from React rendering)
+- Refactor React components (`PagedEditor`, `DocxEditor`, hooks) to be thin wrappers around the extracted managers
+- Existing behavior unchanged — internal refactor only
+
+## Capabilities
+
+### New Capabilities
+
+- `layout-coordinator`: Framework-agnostic class coordinating the PM state → layout engine → layout painter → selection overlay pipeline, including caching, invalidation, and resize handling
+- `editor-coordinator`: Framework-agnostic class managing document lifecycle (parse, load, save), zoom, font loading, extension manager, and agent command dispatch
+- `manager-classes`: Framework-agnostic manager classes extracted from React hooks — `ClipboardManager`, `AutoSaveManager`, `TableSelectionManager`, `ErrorManager`, `PluginLifecycleManager`
+- `render-async-interface`: Framework-agnostic interface for imperatively mounting an editor into a container element, with React and Vue implementations
+
+### Modified Capabilities
+
+## Impact
+
+- **`@eigenpal/docx-core`**: Gains new exports — coordinator classes, manager classes, `RenderAsyncHandle` interface
+- **`@eigenpal/docx-js-editor`**: `PagedEditor.tsx`, `DocxEditor.tsx`, and hooks become thin React wrappers (~50-70% line reduction). No public API changes.
+- **`@eigenpal/docx-editor-vue`**: Vue contributor can now build components by wrapping the same coordinators/managers in Vue composables instead of reverse-engineering React logic
+- **Testing**: Manager classes are unit-testable in isolation (no DOM/React needed for logic tests)
+- **Risk**: Large internal refactor touching the two biggest components. Requires careful incremental extraction with E2E test validation at each step.

--- a/openspec/changes/extract-framework-agnostic-managers/specs/editor-coordinator/spec.md
+++ b/openspec/changes/extract-framework-agnostic-managers/specs/editor-coordinator/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: EditorCoordinator manages document lifecycle
+
+The `EditorCoordinator` class SHALL manage document parsing, loading, font loading, and saving. It SHALL replace the document lifecycle state currently in `DocxEditor.tsx`.
+
+#### Scenario: Load a DOCX file
+
+- **WHEN** `EditorCoordinator.loadDocument(buffer)` is called with a DOCX file buffer
+- **THEN** it SHALL parse the document, load required fonts, and notify subscribers when ready
+- **AND** `getDocument()` SHALL return the parsed `Document`
+
+#### Scenario: Save the current document
+
+- **WHEN** `EditorCoordinator.save()` is called
+- **THEN** it SHALL serialize the current ProseMirror state back to a DOCX blob
+- **AND** return the blob to the caller
+
+### Requirement: EditorCoordinator manages zoom
+
+The `EditorCoordinator` SHALL track the current zoom level.
+
+#### Scenario: Change zoom level
+
+- **WHEN** `setZoom(level)` is called
+- **THEN** subscribers SHALL be notified of the new zoom level
+- **AND** `getZoom()` SHALL return the updated value
+
+### Requirement: EditorCoordinator manages extension manager
+
+The `EditorCoordinator` SHALL hold and initialize the `ExtensionManager` instance, building the ProseMirror schema and runtime.
+
+#### Scenario: Initialize extensions
+
+- **WHEN** `EditorCoordinator` is constructed with an extension configuration
+- **THEN** it SHALL create an `ExtensionManager`, build the schema, and expose it via `getSchema()`
+- **AND** after `EditorState` is created, `initializeRuntime()` SHALL be called
+
+### Requirement: EditorCoordinator dispatches agent commands
+
+The `EditorCoordinator` SHALL accept and execute agent commands against the current document.
+
+#### Scenario: Execute an agent command
+
+- **WHEN** `executeCommand(command)` is called
+- **THEN** it SHALL apply the command to the current document using the agent executor
+- **AND** update the document state
+- **AND** notify subscribers of the document change
+
+### Requirement: EditorCoordinator supports external store subscription
+
+The `EditorCoordinator` SHALL implement the same `subscribe(listener)` / `getSnapshot()` pattern as `LayoutCoordinator`.
+
+#### Scenario: Subscribe to editor state changes
+
+- **WHEN** a framework component subscribes to the coordinator
+- **THEN** it SHALL be notified on document load, zoom change, or command execution
+
+### Requirement: EditorCoordinator has zero framework dependencies
+
+The `EditorCoordinator` class SHALL import only from `@eigenpal/docx-core` internals and vanilla APIs.
+
+#### Scenario: Verify no framework imports
+
+- **WHEN** inspecting `EditorCoordinator` source
+- **THEN** it SHALL have zero imports from `react`, `react-dom`, `vue`, or any UI framework

--- a/openspec/changes/extract-framework-agnostic-managers/specs/layout-coordinator/spec.md
+++ b/openspec/changes/extract-framework-agnostic-managers/specs/layout-coordinator/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: LayoutCoordinator manages the layout pipeline
+
+The `LayoutCoordinator` class SHALL manage the full layout pipeline: converting PM state to flow blocks, measuring blocks, running the layout engine, and triggering the layout painter. It SHALL replace the layout-related state currently in `PagedEditor.tsx`.
+
+#### Scenario: Compute layout from ProseMirror state
+
+- **WHEN** the ProseMirror document changes
+- **AND** `LayoutCoordinator.updateDocument(doc, styles, theme)` is called
+- **THEN** it SHALL recompute flow blocks, measures, and layout
+- **AND** notify subscribers of the new layout
+
+#### Scenario: Cache layout when inputs unchanged
+
+- **WHEN** `updateDocument()` is called with the same document, styles, and theme
+- **THEN** it SHALL return the cached layout without recomputation
+
+### Requirement: LayoutCoordinator manages selection state
+
+The `LayoutCoordinator` SHALL track selection rectangles, caret position, drag state, and selection anchor.
+
+#### Scenario: Update selection from ProseMirror
+
+- **WHEN** the ProseMirror selection changes
+- **AND** `LayoutCoordinator.updateSelection(selectionRects, caretPosition)` is called
+- **THEN** subscribers SHALL be notified with the new selection state
+
+#### Scenario: Track drag selection
+
+- **WHEN** `startDrag(anchor)` is called
+- **THEN** the coordinator SHALL enter drag mode
+- **WHEN** `updateDrag(currentPos)` is called
+- **THEN** it SHALL update the selection range
+- **WHEN** `endDrag()` is called
+- **THEN** it SHALL finalize the selection and exit drag mode
+
+### Requirement: LayoutCoordinator manages column and image resize
+
+The `LayoutCoordinator` SHALL track table column resize state and image resize/interaction state.
+
+#### Scenario: Start column resize
+
+- **WHEN** `startColumnResize(tableInfo, columnIndex, startX)` is called
+- **THEN** the coordinator SHALL track original column widths and resize progress
+- **WHEN** `updateColumnResize(currentX)` is called
+- **THEN** it SHALL compute new column widths and notify subscribers
+
+#### Scenario: Track image interaction
+
+- **WHEN** `setSelectedImage(imageInfo)` is called
+- **THEN** subscribers SHALL be notified of the selected image
+- **WHEN** `clearSelectedImage()` is called
+- **THEN** the image selection SHALL be cleared
+
+### Requirement: LayoutCoordinator supports external store subscription
+
+The `LayoutCoordinator` SHALL implement a `subscribe(listener)` / `getSnapshot()` pattern compatible with React's `useSyncExternalStore` and Vue's manual subscription.
+
+#### Scenario: React component subscribes
+
+- **WHEN** a React component calls `useSyncExternalStore(coordinator.subscribe, coordinator.getSnapshot)`
+- **THEN** it SHALL re-render when coordinator state changes
+
+#### Scenario: Unsubscribe on cleanup
+
+- **WHEN** the unsubscribe function returned by `subscribe()` is called
+- **THEN** the listener SHALL no longer be notified of state changes
+
+### Requirement: LayoutCoordinator has zero framework dependencies
+
+The `LayoutCoordinator` class SHALL import only from `@eigenpal/docx-core` internals and vanilla DOM APIs. It SHALL NOT import React, Vue, or any framework.
+
+#### Scenario: Verify no framework imports
+
+- **WHEN** inspecting `LayoutCoordinator` source
+- **THEN** it SHALL have zero imports from `react`, `react-dom`, `vue`, or any UI framework

--- a/openspec/changes/extract-framework-agnostic-managers/specs/manager-classes/spec.md
+++ b/openspec/changes/extract-framework-agnostic-managers/specs/manager-classes/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: ClipboardManager handles clipboard operations
+
+The `ClipboardManager` class SHALL handle clipboard read/write, DOM selection traversal, and formatting extraction without framework dependencies.
+
+#### Scenario: Copy selection to clipboard
+
+- **WHEN** `ClipboardManager.copy(editorView)` is called
+- **THEN** it SHALL read the current DOM selection, extract formatting from computed styles, and write to the system clipboard
+
+#### Scenario: Paste from clipboard
+
+- **WHEN** `ClipboardManager.paste(editorView)` is called
+- **THEN** it SHALL read from the system clipboard, convert HTML/plain text to ProseMirror content, and insert at the current selection
+
+#### Scenario: Extract formatting from DOM elements
+
+- **WHEN** `ClipboardManager.extractFormattingFromElement(element)` is called
+- **THEN** it SHALL use `window.getComputedStyle()` to extract font, size, color, bold, italic, and other formatting properties
+- **AND** return a framework-agnostic formatting object
+
+### Requirement: AutoSaveManager handles persistence
+
+The `AutoSaveManager` class SHALL handle debounced saving to localStorage and restore on load.
+
+#### Scenario: Auto-save document changes
+
+- **WHEN** the document changes
+- **AND** `AutoSaveManager.onDocumentChanged(doc)` is called
+- **THEN** it SHALL debounce and save to localStorage after the configured delay
+
+#### Scenario: Restore saved document
+
+- **WHEN** `AutoSaveManager.restore(key)` is called
+- **THEN** it SHALL return the saved document buffer from localStorage if it exists
+- **AND** return `null` if no saved document exists
+
+#### Scenario: Clear saved document
+
+- **WHEN** `AutoSaveManager.clear(key)` is called
+- **THEN** it SHALL remove the saved document from localStorage
+
+### Requirement: TableSelectionManager handles multi-cell selection
+
+The `TableSelectionManager` class SHALL manage table cell selection state using data attribute queries on the DOM.
+
+#### Scenario: Select a range of cells
+
+- **WHEN** `TableSelectionManager.selectRange(startCell, endCell)` is called
+- **THEN** it SHALL compute the rectangular selection of cells between start and end
+- **AND** `getSelectedCells()` SHALL return the selected cell coordinates
+
+#### Scenario: Query cell from DOM element
+
+- **WHEN** `TableSelectionManager.getCellFromElement(element)` is called
+- **THEN** it SHALL read `data-table-index`, `data-row`, `data-col` attributes
+- **AND** return the cell coordinates or `null` if the element is not a table cell
+
+#### Scenario: Clear selection
+
+- **WHEN** `TableSelectionManager.clearSelection()` is called
+- **THEN** `getSelectedCells()` SHALL return an empty array
+- **AND** subscribers SHALL be notified
+
+### Requirement: ErrorManager handles error notifications
+
+The `ErrorManager` class SHALL replace React's `componentDidCatch` + context pattern with a framework-agnostic pub/sub error notification system.
+
+#### Scenario: Show an error notification
+
+- **WHEN** `ErrorManager.showError(message, options)` is called
+- **THEN** subscribers SHALL be notified with the new error notification
+- **AND** `getNotifications()` SHALL include the new error
+
+#### Scenario: Dismiss an error
+
+- **WHEN** `ErrorManager.dismiss(id)` is called
+- **THEN** the notification SHALL be removed
+- **AND** subscribers SHALL be notified
+
+#### Scenario: Subscribe to error notifications
+
+- **WHEN** a framework component subscribes via `ErrorManager.subscribe(listener)`
+- **THEN** it SHALL be called whenever notifications change
+
+### Requirement: PluginLifecycleManager handles plugin state
+
+The `PluginLifecycleManager` class SHALL manage EditorPlugin lifecycle — initialization, state tracking, dispatch wrapping, CSS injection, and DOM event listening — without framework dependencies.
+
+#### Scenario: Initialize plugins
+
+- **WHEN** `PluginLifecycleManager.initialize(plugins, editorView)` is called
+- **THEN** it SHALL call `plugin.initialize(editorView)` for each plugin
+- **AND** store the initial plugin states
+
+#### Scenario: Update plugin states on editor change
+
+- **WHEN** the editor state changes
+- **AND** `PluginLifecycleManager.updateStates(editorView)` is called
+- **THEN** it SHALL call `plugin.onStateChange(editorView)` for each plugin
+- **AND** notify subscribers if any plugin state changed
+
+#### Scenario: Inject plugin CSS
+
+- **WHEN** a plugin has a `styles` property
+- **THEN** `PluginLifecycleManager` SHALL inject a `<style>` element with the plugin's CSS
+- **AND** remove it when the plugin is destroyed
+
+#### Scenario: Destroy plugins
+
+- **WHEN** `PluginLifecycleManager.destroy()` is called
+- **THEN** it SHALL call `plugin.destroy()` for each plugin
+- **AND** remove all injected styles
+- **AND** remove all DOM event listeners
+
+### Requirement: All manager classes have zero framework dependencies
+
+All manager classes SHALL be plain TypeScript classes with no imports from React, Vue, or any UI framework.
+
+#### Scenario: Verify framework independence
+
+- **WHEN** inspecting the source of `ClipboardManager`, `AutoSaveManager`, `TableSelectionManager`, `ErrorManager`, and `PluginLifecycleManager`
+- **THEN** none SHALL import from `react`, `react-dom`, `vue`, or any UI framework

--- a/openspec/changes/extract-framework-agnostic-managers/specs/render-async-interface/spec.md
+++ b/openspec/changes/extract-framework-agnostic-managers/specs/render-async-interface/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: EditorHandle interface in core
+
+The `@eigenpal/docx-core` package SHALL export an `EditorHandle` interface defining the contract for an imperatively mounted editor instance.
+
+#### Scenario: EditorHandle provides document operations
+
+- **WHEN** a consumer obtains an `EditorHandle` from a `renderAsync` implementation
+- **THEN** it SHALL expose `save(): Promise<Blob>`, `getDocument(): Document`, `focus(): void`, and `destroy(): void`
+
+#### Scenario: EditorHandle is framework-agnostic
+
+- **WHEN** inspecting the `EditorHandle` interface
+- **THEN** it SHALL NOT reference React, Vue, or any framework-specific types
+
+### Requirement: React renderAsync implements EditorHandle
+
+The `@eigenpal/docx-js-editor` package SHALL export a `renderAsync(input, container, options): Promise<EditorHandle>` function that mounts a React editor into a DOM element.
+
+#### Scenario: Mount editor imperatively with React
+
+- **WHEN** `renderAsync(docxBuffer, containerDiv, options)` is called
+- **THEN** it SHALL create a React root, render the editor, and resolve with an `EditorHandle`
+- **AND** calling `handle.destroy()` SHALL unmount the React root
+
+#### Scenario: Existing renderAsync behavior preserved
+
+- **WHEN** existing code uses `renderAsync`
+- **THEN** the returned handle SHALL provide the same capabilities as the current implementation
+
+### Requirement: Vue renderAsync scaffolded
+
+The `@eigenpal/docx-editor-vue` package SHALL scaffold a `renderAsync(input, container, options): Promise<EditorHandle>` function signature using `Vue.createApp().mount()`.
+
+#### Scenario: Vue renderAsync placeholder exists
+
+- **WHEN** inspecting `@eigenpal/docx-editor-vue` exports
+- **THEN** a `renderAsync` function type or stub SHALL exist
+- **AND** it SHALL return `Promise<EditorHandle>` from `@eigenpal/docx-core`

--- a/openspec/changes/extract-framework-agnostic-managers/tasks.md
+++ b/openspec/changes/extract-framework-agnostic-managers/tasks.md
@@ -1,0 +1,73 @@
+## 1. Shared Infrastructure
+
+- [ ] 1.1 Create `packages/core/src/managers/` directory and a base `Subscribable` class with `subscribe(listener)` / `getSnapshot()` / `notify()` pattern
+- [ ] 1.2 Add `EditorHandle` interface to `packages/core/src/managers/types.ts` (save, getDocument, focus, destroy)
+- [ ] 1.3 Export all manager types from `@eigenpal/docx-core`
+
+## 2. AutoSaveManager (lowest risk)
+
+- [ ] 2.1 Extract localStorage persistence logic from `useAutoSave` hook into `packages/core/src/managers/AutoSaveManager.ts`
+- [ ] 2.2 Refactor `useAutoSave` hook to be a thin wrapper around `AutoSaveManager`
+- [ ] 2.3 Run `bun run typecheck` and targeted E2E tests to verify no regression
+
+## 3. TableSelectionManager
+
+- [ ] 3.1 Extract multi-cell selection state machine from `useTableSelection` hook into `packages/core/src/managers/TableSelectionManager.ts`
+- [ ] 3.2 Extract DOM data-attribute queries (`data-table-index`, `data-row`, `data-col`) into the manager
+- [ ] 3.3 Refactor `useTableSelection` hook to wrap `TableSelectionManager`
+- [ ] 3.4 Run typecheck and table-related E2E tests
+
+## 4. ClipboardManager
+
+- [ ] 4.1 Extract `getSelectionRuns()`, `extractFormattingFromElement()`, `createSelectionFromDOM()` helper functions into `packages/core/src/managers/ClipboardManager.ts`
+- [ ] 4.2 Extract clipboard read/write logic (navigator.clipboard API) into the manager
+- [ ] 4.3 Refactor `useClipboard` hook to wrap `ClipboardManager`
+- [ ] 4.4 Run typecheck and clipboard-related E2E tests (known flaky — verify no new failures)
+
+## 5. ErrorManager
+
+- [ ] 5.1 Create `packages/core/src/managers/ErrorManager.ts` with pub/sub notification system (showError, dismiss, subscribe)
+- [ ] 5.2 Refactor `ErrorBoundary.tsx` and `ErrorProvider` to use `ErrorManager` internally
+- [ ] 5.3 Run typecheck and verify error handling in E2E tests
+
+## 6. PluginLifecycleManager
+
+- [ ] 6.1 Extract plugin initialization, state tracking, and destroy logic from `PluginHost.tsx` into `packages/core/src/managers/PluginLifecycleManager.ts`
+- [ ] 6.2 Extract dispatch wrapping logic (monkey-patching `editorView.dispatch`) into the manager
+- [ ] 6.3 Extract CSS injection (`injectStyles`/removal) into a `StyleManager` utility in the manager
+- [ ] 6.4 Extract DOM event listener setup (input, focus, click → plugin state update) into the manager
+- [ ] 6.5 Refactor `PluginHost.tsx` to use `PluginLifecycleManager` for lifecycle, keep only React panel/overlay rendering
+- [ ] 6.6 Run typecheck and template plugin E2E tests
+
+## 7. LayoutCoordinator
+
+- [ ] 7.1 Create `packages/core/src/managers/LayoutCoordinator.ts` with layout pipeline state (blocks, measures, layout, pending flag)
+- [ ] 7.2 Extract flow block conversion + measurement + layout engine call from `PagedEditor.tsx` into `LayoutCoordinator.updateDocument()`
+- [ ] 7.3 Extract selection state (selectionRects, caretPosition, isDragging, dragAnchor) into the coordinator
+- [ ] 7.4 Extract column resize state (isResizing, tableInfo, originalWidths) into the coordinator
+- [ ] 7.5 Extract image interaction state (selectedImageInfo, isImageInteracting) into the coordinator
+- [ ] 7.6 Refactor `PagedEditor.tsx` to subscribe to `LayoutCoordinator` via `useSyncExternalStore`
+- [ ] 7.7 Run typecheck and full formatting + rendering E2E tests
+
+## 8. EditorCoordinator
+
+- [ ] 8.1 Create `packages/core/src/managers/EditorCoordinator.ts` with document lifecycle state (document, isReady, zoom)
+- [ ] 8.2 Extract document parsing and font loading logic from `DocxEditor.tsx` into `EditorCoordinator.loadDocument()`
+- [ ] 8.3 Extract zoom management into the coordinator
+- [ ] 8.4 Extract extension manager initialization into the coordinator
+- [ ] 8.5 Extract agent command execution into the coordinator
+- [ ] 8.6 Refactor `DocxEditor.tsx` to subscribe to `EditorCoordinator` via `useSyncExternalStore`
+- [ ] 8.7 Run typecheck and full E2E test suite
+
+## 9. renderAsync Refactor
+
+- [ ] 9.1 Refactor `renderAsync.ts` in React package to return `EditorHandle` (from core) instead of current ad-hoc return type
+- [ ] 9.2 Scaffold `renderAsync` stub in Vue package returning `Promise<EditorHandle>`
+- [ ] 9.3 Verify existing `renderAsync` consumers still work
+
+## 10. Final Validation
+
+- [ ] 10.1 Verify all managers have zero React/Vue imports (`grep -r "from 'react'" packages/core/src/managers/`)
+- [ ] 10.2 Verify `PagedEditor.tsx` and `DocxEditor.tsx` line count reduced by ~50%
+- [ ] 10.3 Run full Playwright E2E test suite
+- [ ] 10.4 Add unit tests for manager classes (at least AutoSaveManager, TableSelectionManager, ErrorManager)


### PR DESCRIPTION
## Summary

- Adds two OpenSpec change proposals scoping the work to make the editor framework-agnostic, enabling community Vue/Svelte wrappers without forking
- **Phase 1 (`extract-core-monorepo`)**: Split into `@eigenpal/docx-core` (framework-agnostic, ~80% of code) and `@eigenpal/docx-js-editor` (React UI), with `@eigenpal/docx-editor-vue` scaffold. Includes cross-framework plugin abstraction (`EditorPluginCore` → `ReactEditorPlugin`/`VueEditorPlugin`) and shared Playwright E2E test infrastructure
- **Phase 2 (`extract-framework-agnostic-managers`)**: Extract business logic from React components/hooks into plain TS manager classes (`LayoutCoordinator`, `EditorCoordinator`, `ClipboardManager`, `AutoSaveManager`, etc.) so Vue contributors can wrap the same logic in Vue composables instead of reimplementing it

Each change includes: proposal, design doc, detailed specs with testable scenarios, and implementation task breakdown.

## Test plan

- [ ] Review proposals and design docs for architectural soundness
- [ ] Review specs for completeness and testability
- [ ] Review task ordering for dependency correctness
- [ ] Verify no source code changes — specs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)