### PR TITLE
fix: suggestion mode marks too much text when typing over selection

### DIFF
--- a/packages/core/src/prosemirror/plugins/suggestionMode.ts
+++ b/packages/core/src/prosemirror/plugins/suggestionMode.ts
@@ -113,6 +113,41 @@ function markRangeAsDeleted(
 }
 
 /**
+ * Insert text as a tracked insertion, optionally marking replaced selection as deletion.
+ */
+function applySuggestionInsert(
+  view: EditorView,
+  from: number,
+  to: number,
+  text: string,
+  pluginState: SuggestionModeState
+): boolean {
+  const insertionType = view.state.schema.marks.insertion;
+  if (!insertionType) return false;
+
+  const tr = view.state.tr;
+  tr.setMeta(SUGGESTION_META, true);
+
+  const insertAttrs =
+    findAdjacentRevision(view.state.doc, from, 'insertion', pluginState.author) ||
+    makeMarkAttrs(pluginState);
+
+  if (from !== to) {
+    const deletionType = view.state.schema.marks.deletion;
+    if (deletionType) {
+      markRangeAsDeleted(tr, view.state.doc, from, to, insertionType, deletionType, pluginState);
+    }
+  }
+
+  const insertAt = tr.mapping.map(to);
+  tr.insertText(text, insertAt, insertAt);
+  tr.addMark(insertAt, insertAt + text.length, insertionType.create(insertAttrs));
+
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
  * Handle delete (forward or backward) in suggestion mode.
  */
 function handleSuggestionDelete(
@@ -205,6 +240,24 @@ export function createSuggestionModePlugin(initialActive = false, author = 'User
     },
 
     props: {
+      handleDOMEvents: {
+        // Intercept text input at the DOM level. ProseMirror's handleTextInput
+        // is NOT reliably called when the hidden PM has complex mark structures
+        // (it requires the change to span exactly one text node). By handling
+        // beforeinput directly, we ensure suggestion mode always processes input.
+        beforeinput(view: EditorView, event: InputEvent) {
+          const pluginState = suggestionModeKey.getState(view.state);
+          if (!pluginState?.active) return false;
+
+          if (event.inputType === 'insertText' && event.data) {
+            event.preventDefault();
+            const { from, to } = view.state.selection;
+            return applySuggestionInsert(view, from, to, event.data, pluginState);
+          }
+
+          return false;
+        },
+      },
       // Intercept Backspace and Delete to mark as deletion
       handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
         const pluginState = suggestionModeKey.getState(view.state);
@@ -219,47 +272,11 @@ export function createSuggestionModePlugin(initialActive = false, author = 'User
         return false;
       },
 
-      // Intercept text input to add insertion marks
+      // Backup: also handle via PM's handleTextInput for simple cases
       handleTextInput(view: EditorView, from: number, to: number, text: string): boolean {
         const pluginState = suggestionModeKey.getState(view.state);
         if (!pluginState?.active) return false;
-
-        const insertionType = view.state.schema.marks.insertion;
-        if (!insertionType) return false;
-
-        const tr = view.state.tr;
-        tr.setMeta(SUGGESTION_META, true);
-
-        // Reuse adjacent insertion's revisionId so consecutive typing groups together
-        const insertAttrs =
-          findAdjacentRevision(view.state.doc, from, 'insertion', pluginState.author) ||
-          makeMarkAttrs(pluginState);
-
-        // If replacing a selection, mark the replaced content as deletion first
-        if (from !== to) {
-          const deletionType = view.state.schema.marks.deletion;
-          if (deletionType) {
-            markRangeAsDeleted(
-              tr,
-              view.state.doc,
-              from,
-              to,
-              insertionType,
-              deletionType,
-              pluginState
-            );
-          }
-        }
-
-        // Insert new text after any deletion-marked content (not replacing it)
-        const insertAt = tr.mapping.map(to);
-        tr.insertText(text, insertAt, insertAt);
-
-        // Mark the inserted text with insertion mark
-        tr.addMark(insertAt, insertAt + text.length, insertionType.create(insertAttrs));
-
-        view.dispatch(tr.scrollIntoView());
-        return true;
+        return applySuggestionInsert(view, from, to, text, pluginState);
       },
     },
 
@@ -284,19 +301,19 @@ export function createSuggestionModePlugin(initialActive = false, author = 'User
         const stepMap = step.getMap();
         stepMap.forEach((_oldFrom, _oldTo, newFrom, newTo) => {
           if (newTo > newFrom) {
-            // Skip ranges already handled by handleTextInput / handleSuggestionDelete
-            let allMarked = true;
-            newState.doc.nodesBetween(newFrom, newTo, (node) => {
-              if (node.isText) {
-                const hasTrackedMark = node.marks.some(
-                  (m) => m.type === insertionType || (deletionType && m.type === deletionType)
-                );
-                if (!hasTrackedMark) allMarked = false;
+            // Only mark text nodes that don't already have tracked change marks.
+            // Marking the entire range would overwrite existing marks from other authors.
+            newState.doc.nodesBetween(newFrom, newTo, (node, pos) => {
+              if (!node.isText) return;
+              const hasTrackedMark = node.marks.some(
+                (m) => m.type === insertionType || (deletionType && m.type === deletionType)
+              );
+              if (!hasTrackedMark) {
+                const nodeStart = Math.max(pos, newFrom);
+                const nodeEnd = Math.min(pos + node.nodeSize, newTo);
+                tr.addMark(nodeStart, nodeEnd, insertionType.create(markAttrs));
               }
             });
-            if (!allMarked) {
-              tr.addMark(newFrom, newTo, insertionType.create(markAttrs));
-            }
           }
         });
       });


### PR DESCRIPTION
## Summary

- **Bug**: In suggestion mode, selecting text and typing caused the insertion mark to extend far beyond the typed characters (e.g., selecting "users" and typing "df" marked the entire remaining sentence as insertion)
- **Root cause**: ProseMirror's `handleTextInput` is not reliably called when the DOM has complex mark structures. The input fell through to `appendTransaction`, which marked the entire step range as insertion
- **Fix**: Added `beforeinput` DOM event handler to intercept text input before ProseMirror processes it, and fixed `appendTransaction` to mark individual unmarked text nodes instead of the full range

## Changes (1 file)

`packages/core/src/prosemirror/plugins/suggestionMode.ts`:
1. **`beforeinput` handler** — intercepts `insertText` events at the DOM level, calls `preventDefault()`, and applies tracked-change logic directly
2. **`appendTransaction` fix** — iterates individual text nodes and only marks those without existing tracked-change marks (prevents overwriting other authors' marks)
3. **`applySuggestionInsert` helper** — extracted shared logic from `beforeinput` and `handleTextInput` to eliminate duplication (DRY)

## Test plan

- [x] Typecheck passes (all 3 packages)
- [x] 125 scenario-driven tests pass
- [x] 29/34 text-editing tests pass (5 failures are pre-existing known flaky tests)
- [x] Manually verified in Chrome: select "users", type "df" → only "df" gets insertion mark, "users" gets deletion mark, surrounding text unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)