### PR TITLE
fix: bundle docx-core into docx-js-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ function Editor({ file }: { file: ArrayBuffer }) {
 
 ## Packages
 
-| Package                                      | Description                                                      |
-| -------------------------------------------- | ---------------------------------------------------------------- |
-| [`@eigenpal/docx-js-editor`](packages/react) | React UI — toolbar, paged editor, plugins. **Install this one.** |
-| [`@eigenpal/docx-core`](packages/core)       | Framework-agnostic core — parsing, ProseMirror, layout engine    |
-| [`@eigenpal/docx-editor-vue`](packages/vue)  | Vue.js scaffold — contributions welcome                          |
+| Package                                      | Description                                                  |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| [`@eigenpal/docx-js-editor`](packages/react) | React UI — toolbar, paged editor, plugins. **Install this.** |
+| [`@eigenpal/docx-editor-vue`](packages/vue)  | Vue.js scaffold — contributions welcome                      |
 
 ## Plugins
 

--- a/bun.lock
+++ b/bun.lock
@@ -59,9 +59,16 @@
       "name": "@eigenpal/docx-js-editor",
       "version": "0.0.17",
       "dependencies": {
-        "@eigenpal/docx-core": "workspace:*",
         "@radix-ui/react-select": "^2.2.6",
         "clsx": "^2.1.0",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-history": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.19.4",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-view": "^1.32.7",
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -90,9 +90,16 @@
     }
   },
   "dependencies": {
-    "@eigenpal/docx-core": "workspace:*",
     "@radix-ui/react-select": "^2.2.6",
-    "clsx": "^2.1.0"
+    "clsx": "^2.1.0",
+    "prosemirror-commands": "^1.5.2",
+    "prosemirror-dropcursor": "^1.8.2",
+    "prosemirror-history": "^1.4.0",
+    "prosemirror-keymap": "^1.2.2",
+    "prosemirror-model": "^1.19.4",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-tables": "^1.8.5",
+    "prosemirror-view": "^1.32.7"
   },
   "keywords": [
     "docx",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -22,10 +22,6 @@ export default defineConfig({
   external: [
     'react',
     'react-dom',
-    '@eigenpal/docx-core',
-    '@eigenpal/docx-core/headless',
-    '@eigenpal/docx-core/core-plugins',
-    '@eigenpal/docx-core/mcp',
     'prosemirror-commands',
     'prosemirror-dropcursor',
     'prosemirror-history',


### PR DESCRIPTION
## Summary

- `@eigenpal/docx-js-editor@0.0.17` was published with `@eigenpal/docx-core: workspace:*` as a dependency, but `docx-core` was never published to npm — breaking `npm install` for consumers
- Instead of publishing a separate core package, bundle it directly into `docx-js-editor` via tsup
- Prosemirror packages (which are externalized in the build) are now listed as direct dependencies
- Removed `@eigenpal/docx-core` from the README packages table since users only need the client packages (react/vue)

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Built output has no external `@eigenpal/docx-core` references
- [ ] Verify `npm install @eigenpal/docx-js-editor` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)