### PR TITLE
fix: compile Tailwind utilities into dist/styles.css

### DIFF
--- a/tailwind.config.lib.js
+++ b/tailwind.config.lib.js
@@ -1,10 +1,17 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __configDir = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ['class'],
   // Scope all utilities under .ep-root to avoid clashing with host app CSS
   important: '.ep-root',
   // Only scan library source files, not demo
-  content: ['./packages/react/src/**/*.{ts,tsx}'],
+  // Must use absolute paths because build:css runs from packages/react/
+  // but this config lives at the repo root
+  content: [path.join(__configDir, 'packages/react/src/**/*.{ts,tsx}')],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

- **Bug:** `tailwind.config.lib.js` used a relative content path (`./packages/react/src/**/*.{ts,tsx}`) but `build:css` runs from `packages/react/`. Tailwind v3 resolves content paths relative to CWD, so it was scanning `packages/react/packages/react/src/` (doesn't exist) → **zero utility classes** in `dist/styles.css`.
- **Fix:** Use `import.meta.url` to resolve the content path as absolute, so it works regardless of CWD.
- **Result:** `dist/styles.css` now ships all 169 Tailwind utility classes used by the components (`flex`, `rounded-md`, `shadow-lg`, `z-50`, `text-primary`, `inline-flex`, etc.). Consumers just `import '@eigenpal/docx-js-editor/styles.css'` — no `@source` directives or color token mappings needed.

Fixes the root cause of eigenpal/eigenpal-landing#28.

## Before / After

| | Before | After |
|---|---|---|
| `dist/styles.css` size | 19 KB | 22 KB |
| Tailwind utility classes | 0 | 169 |

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Verified `dist/styles.css` contains key utilities (`flex`, `rounded-md`, `shadow-lg`, `z-50`, `text-primary`, `inline-flex`, `items-center`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)