### PR TITLE
fix: publish from packages/react and generate npm README with absolute URLs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,12 +46,14 @@ jobs:
 
       - name: Publish (dry run)
         if: ${{ github.event.inputs.dry-run == 'true' }}
+        working-directory: packages/react
         run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         if: ${{ github.event.inputs.dry-run != 'true' }}
+        working-directory: packages/react
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,6 +75,7 @@
   "scripts": {
     "build": "tsup && bun run build:css",
     "build:css": "tailwindcss -c ../../tailwind.config.lib.js -i ./src/styles/editor.css -o ./dist/styles.css --minify",
+    "prepublishOnly": "sed -e 's|\\./assets/|https://raw.githubusercontent.com/eigenpal/docx-js-editor/main/assets/|g' -e 's|(packages/|(https://github.com/eigenpal/docx-js-editor/tree/main/packages/|g' -e 's|(docs/|(https://github.com/eigenpal/docx-js-editor/blob/main/docs/|g' -e 's|(examples/|(https://github.com/eigenpal/docx-js-editor/tree/main/examples/|g' ../../README.md > README.md",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Add `working-directory: packages/react` to publish workflow steps so `npm publish` runs from the correct package directory
- Add `prepublishOnly` script that rewrites relative asset/link paths in README.md to absolute GitHub URLs for npm
- Add `.gitignore` in `packages/react/` to ignore the generated README.md

## Test plan
- [ ] Run publish workflow with dry-run to verify it executes from the correct directory
- [ ] Verify `prepublishOnly` script generates a README with correct absolute URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)