### PR TITLE
Fix: disable sourcemaps to reduce package from 16MB to 3.5MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docx-editor-monorepo",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eigenpal/docx-js-editor",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A browser-based DOCX template editor with variable insertion support",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'tsup';
 
-const isProd = process.env.NODE_ENV === 'production';
-
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
@@ -15,7 +13,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   splitting: true,
-  sourcemap: !isProd,
+  sourcemap: false,
   clean: true,
   treeshake: true,
   minify: true,


### PR DESCRIPTION
## Summary
- Disable sourcemaps in `packages/react/tsup.config.ts` — the `sourcemap: !isProd` condition was always true during publish since `NODE_ENV` wasn't set, causing 68 `.map` files (~13MB) to ship in the npm tarball
- Bump version to 0.0.21

**Size history:**
| Version | Unpacked Size |
|---------|--------------|
| 0.0.16  | 2.5 MB       |
| 0.0.17  | 4.5 MB       |
| 0.0.19  | 16.1 MB      |
| 0.0.21  | ~3.5 MB      |

## Test plan
- [ ] `bun run build` in `packages/react` produces no `.map` files
- [ ] `npm pack --dry-run` shows ~3.5MB unpacked size

🤖 Generated with [Claude Code](https://claude.com/claude-code)