### PR TITLE
fix: draw top border on table continuation across pages

### DIFF
--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -329,7 +329,8 @@ function renderTableRow(
   context: RenderContext,
   doc: Document,
   spanningCells?: Map<string, SpanningCell>,
-  rowYPositions?: number[]
+  rowYPositions?: number[],
+  isFirstRowInFragment?: boolean
 ): HTMLElement {
   const rowEl = doc.createElement('div');
   rowEl.className = TABLE_CLASS_NAMES.row;
@@ -391,7 +392,7 @@ function renderTableRow(
       }
     }
 
-    const isFirstRow = rowIndex === 0;
+    const isFirstRow = rowIndex === 0 || isFirstRowInFragment === true;
     const isLastRow = rowIndex + rowSpan >= totalRows;
     const isFirstCol = columnIndex === 0;
     const isLastCol = columnIndex + colSpan >= columnWidths.length;
@@ -529,6 +530,8 @@ export function renderTableFragment(
 
     if (!row || !rowMeasure) continue;
 
+    const isFirstRowInFragment = fragment.continuesFromPrev && rowIndex === fragment.fromRow;
+
     const rowEl = renderTableRow(
       row,
       rowMeasure,
@@ -539,7 +542,8 @@ export function renderTableFragment(
       context,
       doc,
       spanningCells,
-      rowYPositions
+      rowYPositions,
+      isFirstRowInFragment
     );
 
     tableEl.appendChild(rowEl);


### PR DESCRIPTION
## Summary
- When a table spans multiple pages, the first row on the continuation page was missing its top border
- Pass `fragment.continuesFromPrev` into `renderTableRow` so the first row of each continuation fragment draws its top border, matching Word and Google Docs behavior

## Test plan
- [ ] Open a DOCX with a table that spans multiple pages
- [ ] Verify the continuation page shows a top border on its first row
- [ ] Verify single-page tables still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)