### PR TITLE
fix: comment button drifts vertically when scrolled (fixes #185)

### DIFF
--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -1168,7 +1168,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
               if (selFrom >= pmStart && selFrom <= pmEnd) {
                 const rect = el.getBoundingClientRect();
                 const parentRect = parentEl.getBoundingClientRect();
-                const top = rect.top - parentRect.top + container.scrollTop;
+                const top = rect.top - parentRect.top;
                 // Position at the right edge of the page (relative to editorContentRef)
                 const left = pageEl
                   ? pageEl.getBoundingClientRect().right - parentRect.left


### PR DESCRIPTION
## Summary
- Remove spurious `+ container.scrollTop` from the floating comment button position calculation
- `getBoundingClientRect()` already returns viewport-relative coords, so adding `scrollTop` double-counted the scroll offset — the button drifted further from the selection the more the user scrolled

## Pre-Landing Review
No issues found. All three review agents (reuse, quality, efficiency) confirmed the 1-line fix is clean and correctly scoped.

## Test plan
- [ ] Open a multi-page DOCX document
- [ ] Select text near the top of the document — verify comment button appears on the same line
- [ ] Scroll down and select text on page 2+ — verify the comment button still appears horizontally aligned with the selection (not drifted below)
- [ ] Click the comment button and verify it opens the comment sidebar correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>