### PR TITLE
fix: make DocxEditor reactive to document/documentBuffer prop changes

### DIFF
--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -935,6 +935,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Hyperlink popup state (Google Docs-style floating popup on link click)
   const [hyperlinkPopupData, setHyperlinkPopupData] = useState<HyperlinkPopupData | null>(null);
 
+  // Monotonically increasing generation counter to discard stale async loads
+  const loadGenerationRef = useRef(0);
+
   // Reset internal state when loading a new document (clears stale refs, comments, tracked changes, etc.)
   const resetForNewDocument = useCallback(() => {
     commentsLoadedRef.current = false;
@@ -953,7 +956,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       clearTimeout(extractTrackedChangesTimerRef.current);
       extractTrackedChangesTimerRef.current = null;
     }
-  }, [findReplace]);
+  }, [findReplace.setMatches]);
 
   // Load a pre-parsed document (used by ref method and internally)
   const loadParsedDocument = useCallback(
@@ -971,20 +974,16 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Load a DOCX buffer (used by ref method and internally)
   const loadBuffer = useCallback(
     async (buffer: DocxInput) => {
+      const generation = ++loadGenerationRef.current;
       resetForNewDocument();
       setState((prev) => ({ ...prev, isLoading: true, parseError: null }));
       try {
         const doc = await parseDocx(buffer);
-        history.reset(doc);
-        setState((prev) => ({
-          ...prev,
-          isLoading: false,
-          parseError: null,
-        }));
-        loadDocumentFonts(doc).catch((err) => {
-          console.warn('Failed to load document fonts:', err);
-        });
+        // Discard result if a newer load was started while we were parsing
+        if (loadGenerationRef.current !== generation) return;
+        loadParsedDocument(doc);
       } catch (error) {
+        if (loadGenerationRef.current !== generation) return;
         const message = error instanceof Error ? error.message : 'Failed to parse document';
         setState((prev) => ({
           ...prev,
@@ -994,10 +993,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         onError?.(error instanceof Error ? error : new Error(message));
       }
     },
-    [resetForNewDocument, history, onError]
+    [resetForNewDocument, loadParsedDocument, onError]
   );
 
-  // Parse document buffer
+  // React to document/documentBuffer prop changes
   useEffect(() => {
     if (!documentBuffer) {
       if (initialDocument) {


### PR DESCRIPTION
## Summary

- **DocxEditor now properly reacts to `document`/`documentBuffer` prop changes** — previously, changing these props after mount left stale internal state (comments, tracked changes, outline headings, find/replace results, etc.), requiring a `key` prop workaround to force remount
- **Added `loadDocument(doc)` and `loadDocumentBuffer(buffer)` ref methods** for programmatic document swapping without changing props
- Extracted `resetForNewDocument()`, `loadParsedDocument()`, and `loadBuffer()` as reusable internal helpers, removing a redundant useEffect

## Test plan

- [x] `bun run typecheck` passes (all 4 packages)
- [x] `demo-docx.spec.ts` — 44/45 pass (1 pre-existing failure unrelated to this change)
- [x] `formatting.spec.ts` — 11/11 pass
- [x] `alignment.spec.ts` + `fonts.spec.ts` — all pass
- [ ] Manual: load doc A → load doc B via prop change → verify comments/tracked changes reset
- [ ] Manual: use `ref.loadDocument(doc)` to swap documents programmatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)