### PR TITLE
fix: drop type:module — Next.js works without transpilePackages

### DIFF
--- a/examples/agent-use-demo/next.config.ts
+++ b/examples/agent-use-demo/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {
-  transpilePackages: ['@eigenpal/docx-js-editor', '@eigenpal/docx-core'],
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/examples/nextjs/next.config.ts
+++ b/examples/nextjs/next.config.ts
@@ -8,7 +8,6 @@ const isMonorepo = fs.existsSync(path.join(monorepoRoot, 'src/index.ts'));
 
 const nextConfig: NextConfig = {
   outputFileTracingRoot: monorepoRoot,
-  transpilePackages: ['@eigenpal/docx-js-editor'],
   webpack: (config, { webpack }) => {
     if (isMonorepo) {
       config.resolve.alias['@eigenpal/docx-js-editor'] = path.join(monorepoRoot, 'src/index.ts');

--- a/packages/agent-use/package.json
+++ b/packages/agent-use/package.json
@@ -2,20 +2,19 @@
   "name": "@eigenpal/docx-editor-agents",
   "version": "0.0.28",
   "description": "Agent-friendly API for DOCX document review — read, comment, propose changes, accept/reject tracked changes",
-  "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./bridge": {
       "types": "./dist/bridge.d.ts",
-      "import": "./dist/bridge.js",
-      "require": "./dist/bridge.cjs"
+      "import": "./dist/bridge.mjs",
+      "require": "./dist/bridge.js"
     }
   },
   "typesVersions": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,35 +3,34 @@
   "version": "0.0.28",
   "private": true,
   "description": "Framework-agnostic core for DOCX parsing, editing, and rendering",
-  "type": "module",
-  "main": "./dist/core.cjs",
-  "module": "./dist/core.js",
+  "main": "./dist/core.js",
+  "module": "./dist/core.mjs",
   "types": "./dist/core.d.ts",
   "exports": {
     ".": {
       "types": "./dist/core.d.ts",
-      "import": "./dist/core.js",
-      "require": "./dist/core.cjs"
+      "import": "./dist/core.mjs",
+      "require": "./dist/core.js"
     },
     "./headless": {
       "types": "./dist/headless.d.ts",
-      "import": "./dist/headless.js",
-      "require": "./dist/headless.cjs"
+      "import": "./dist/headless.mjs",
+      "require": "./dist/headless.js"
     },
     "./core-plugins": {
       "types": "./dist/core-plugins.d.ts",
-      "import": "./dist/core-plugins.js",
-      "require": "./dist/core-plugins.cjs"
+      "import": "./dist/core-plugins.mjs",
+      "require": "./dist/core-plugins.js"
     },
     "./mcp": {
       "types": "./dist/mcp.d.ts",
-      "import": "./dist/mcp.js",
-      "require": "./dist/mcp.cjs"
+      "import": "./dist/mcp.mjs",
+      "require": "./dist/mcp.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "require": "./dist/*.cjs"
+      "import": "./dist/*.mjs",
+      "require": "./dist/*.js"
     }
   },
   "typesVersions": {
@@ -48,7 +47,7 @@
     }
   },
   "bin": {
-    "docx-editor-mcp": "./dist/mcp-cli.js"
+    "docx-editor-mcp": "./dist/mcp-cli.mjs"
   },
   "files": [
     "dist"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,45 +2,44 @@
   "name": "@eigenpal/docx-js-editor",
   "version": "0.0.28",
   "description": "A browser-based DOCX template editor with variable insertion support",
-  "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react.d.ts",
-      "import": "./dist/react.js",
-      "require": "./dist/react.cjs"
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.js"
     },
     "./ui": {
       "types": "./dist/ui.d.ts",
-      "import": "./dist/ui.js",
-      "require": "./dist/ui.cjs"
+      "import": "./dist/ui.mjs",
+      "require": "./dist/ui.js"
     },
     "./core": {
       "types": "./dist/core-reexport.d.ts",
-      "import": "./dist/core-reexport.js",
-      "require": "./dist/core-reexport.cjs"
+      "import": "./dist/core-reexport.mjs",
+      "require": "./dist/core-reexport.js"
     },
     "./headless": {
       "types": "./dist/headless-reexport.d.ts",
-      "import": "./dist/headless-reexport.js",
-      "require": "./dist/headless-reexport.cjs"
+      "import": "./dist/headless-reexport.mjs",
+      "require": "./dist/headless-reexport.js"
     },
     "./core-plugins": {
       "types": "./dist/core-plugins-reexport.d.ts",
-      "import": "./dist/core-plugins-reexport.js",
-      "require": "./dist/core-plugins-reexport.cjs"
+      "import": "./dist/core-plugins-reexport.mjs",
+      "require": "./dist/core-plugins-reexport.js"
     },
     "./mcp": {
       "types": "./dist/mcp-reexport.d.ts",
-      "import": "./dist/mcp-reexport.js",
-      "require": "./dist/mcp-reexport.cjs"
+      "import": "./dist/mcp-reexport.mjs",
+      "require": "./dist/mcp-reexport.js"
     },
     "./styles.css": "./dist/styles.css"
   },


### PR DESCRIPTION
## Summary
- Remove `"type": "module"` from core, react, and agent-use `package.json`
- CJS outputs use `.js` (Node default), ESM outputs use `.mjs`
- Remove `transpilePackages` from nextjs and agent-use-demo examples

Consumers no longer need this in their `next.config.ts`:
```diff
- transpilePackages: ['@eigenpal/docx-js-editor'],
```

This matches the pattern used by sonner, @radix-ui/react-select, clsx, and other packages that work seamlessly with Next.js.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (45 tests)
- [x] agent-use-demo builds without `transpilePackages`
- [ ] Verify published package works in a fresh Next.js project without `transpilePackages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)