### PR TITLE
feat: add showOutlineButton prop to hide floating outline button

### DIFF
--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -271,6 +271,8 @@ export interface DocxEditorProps {
   loadingIndicator?: ReactNode;
   /** Whether to show the document outline sidebar (default: false) */
   showOutline?: boolean;
+  /** Whether to show the floating outline toggle button (default: true) */
+  showOutlineButton?: boolean;
   /** Whether to show print button in toolbar (default: true) */
   showPrintButton?: boolean;
   /** Print options for print preview */
@@ -641,6 +643,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     placeholder,
     loadingIndicator,
     showOutline: showOutlineProp = false,
+    showOutlineButton = true,
     showPrintButton = true,
     printOptions: _printOptions,
     onPrint,
@@ -3712,7 +3715,7 @@ body { background: white; }
               {/* Unified sidebar (comments + plugin items) rendered inside PagedEditor via sidebarOverlay prop */}
 
               {/* Outline toggle button — absolutely positioned below toolbar */}
-              {!showOutline && (
+              {showOutlineButton && !showOutline && (
                 <button
                   className="docx-outline-nav"
                   onClick={handleToggleOutline}


### PR DESCRIPTION
## Summary
- Adds `showOutlineButton` prop (default: `true`) that controls whether the floating outline toggle button is rendered
- Setting `showOutlineButton={false}` hides the button while `showOutline` can still control the sidebar programmatically
- Minimal change: 1 new prop, 1 conditional guard

```tsx
{/* Hide the floating outline button */}
<DocxEditor documentBuffer={buf} showOutlineButton={false} />

{/* Show outline sidebar without the toggle button */}
<DocxEditor documentBuffer={buf} showOutline showOutlineButton={false} />
```

Fixes #209

## Test plan
- [ ] Verify outline button is visible by default (`showOutlineButton` not set)
- [ ] Verify `showOutlineButton={false}` hides the floating button
- [ ] Verify `showOutline={true}` still opens the sidebar when button is hidden
- [ ] Verify `readOnly` mode with `showOutlineButton={false}` has no floating button

🤖 Generated with [Claude Code](https://claude.com/claude-code)