### PR TITLE
refactor: cursor-based sidebar expansion for comments and tracked changes

### DIFF
--- a/packages/agent-use/CHANGELOG.md
+++ b/packages/agent-use/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eigenpal/docx-editor-agents
 
+## 0.0.33
+
+### Patch Changes
+
+- Add i18n
+
 ## 0.0.32
 
 ### Patch Changes

--- a/packages/agent-use/package.json
+++ b/packages/agent-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eigenpal/docx-editor-agents",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Agent-friendly API for DOCX document review — read, comment, propose changes, accept/reject tracked changes",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eigenpal/docx-js-editor
 
+## 0.0.33
+
+### Patch Changes
+
+- Add i18n
+
 ## 0.0.32
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eigenpal/docx-js-editor",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "A browser-based DOCX template editor with variable insertion support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3898,6 +3898,42 @@ body { background: white; }
                           if (view) {
                             const selectionState = extractSelectionState(view.state);
                             handleSelectionChange(selectionState);
+
+                            // Detect comment/tracked-change marks at cursor to open sidebar card
+                            const marks =
+                              view.state.storedMarks || view.state.selection.$from.marks();
+                            let cursorSidebarItem: string | null = null;
+                            for (const mark of marks) {
+                              if (mark.type.name === 'comment' && mark.attrs.commentId != null) {
+                                cursorSidebarItem = `comment-${mark.attrs.commentId}`;
+                                break;
+                              }
+                              if (mark.type.name === 'insertion' && mark.attrs.revisionId != null) {
+                                const revId = String(mark.attrs.revisionId);
+                                const prefix = `tc-${revId}-`;
+                                let match = allSidebarItems.find((i) => i.id.startsWith(prefix));
+                                if (!match && revisionIdAliases) {
+                                  const aliasedId = revisionIdAliases.get(revId);
+                                  if (aliasedId) {
+                                    match = allSidebarItems.find((i) => i.id === aliasedId);
+                                  }
+                                }
+                                if (match) {
+                                  cursorSidebarItem = match.id;
+                                  break;
+                                }
+                              }
+                              if (mark.type.name === 'deletion' && mark.attrs.revisionId != null) {
+                                const revId = String(mark.attrs.revisionId);
+                                const prefix = `tc-${revId}-`;
+                                const match = allSidebarItems.find((i) => i.id.startsWith(prefix));
+                                if (match) {
+                                  cursorSidebarItem = match.id;
+                                  break;
+                                }
+                              }
+                            }
+                            setExpandedSidebarItem(cursorSidebarItem);
                           } else {
                             handleSelectionChange(null);
                           }
@@ -3929,7 +3965,7 @@ body { background: white; }
                                 zoom={state.zoom}
                                 editorContainerRef={scrollContainerRef}
                                 onExpandedItemChange={setExpandedSidebarItem}
-                                revisionIdAliases={revisionIdAliases}
+                                activeItemId={expandedSidebarItem}
                               />
                             )}
                             <CommentMarginMarkers

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3899,9 +3899,15 @@ body { background: white; }
                             const selectionState = extractSelectionState(view.state);
                             handleSelectionChange(selectionState);
 
-                            // Detect comment/tracked-change marks at cursor to open sidebar card
+                            // Detect comment/tracked-change marks at cursor to open sidebar card.
+                            // These marks use inclusive:false, so $from.marks() misses them at
+                            // boundaries. Check nodeAfter/nodeBefore marks for reliable detection.
+                            const $from = view.state.selection.$from;
                             const marks =
-                              view.state.storedMarks || view.state.selection.$from.marks();
+                              view.state.storedMarks ||
+                              $from.nodeAfter?.marks ||
+                              $from.nodeBefore?.marks ||
+                              $from.marks();
                             let cursorSidebarItem: string | null = null;
                             for (const mark of marks) {
                               if (mark.type.name === 'comment' && mark.attrs.commentId != null) {

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3900,11 +3900,9 @@ body { background: white; }
                             handleSelectionChange(selectionState);
 
                             // Detect comment/tracked-change marks at cursor to open sidebar card.
-                            // These marks use inclusive:false, so $from.marks() misses them at
-                            // boundaries. Collect marks from all sources (nodeAfter, nodeBefore,
-                            // storedMarks) since the OR chain short-circuits on empty arrays.
-                            // Search commentSidebarItems (always populated) not allSidebarItems
-                            // (which is empty when sidebar is closed) so we can auto-open it.
+                            // Collect marks from all sources — inclusive:false marks aren't
+                            // reported by $from.marks() at boundaries, and empty arrays are
+                            // truthy so an OR chain would short-circuit.
                             const $from = view.state.selection.$from;
                             const marks = [
                               ...(view.state.storedMarks ?? []),
@@ -3918,29 +3916,23 @@ body { background: white; }
                                 cursorSidebarItem = `comment-${mark.attrs.commentId}`;
                                 break;
                               }
-                              if (mark.type.name === 'insertion' && mark.attrs.revisionId != null) {
+                              if (
+                                (mark.type.name === 'insertion' || mark.type.name === 'deletion') &&
+                                mark.attrs.revisionId != null
+                              ) {
                                 const revId = String(mark.attrs.revisionId);
                                 const prefix = `tc-${revId}-`;
                                 let match = commentSidebarItems.find((i) =>
                                   i.id.startsWith(prefix)
                                 );
+                                // Insertion side of a replacement has a different revisionId;
+                                // check alias map to find the correct sidebar card.
                                 if (!match && revisionIdAliases) {
                                   const aliasedId = revisionIdAliases.get(revId);
                                   if (aliasedId) {
                                     match = commentSidebarItems.find((i) => i.id === aliasedId);
                                   }
                                 }
-                                if (match) {
-                                  cursorSidebarItem = match.id;
-                                  break;
-                                }
-                              }
-                              if (mark.type.name === 'deletion' && mark.attrs.revisionId != null) {
-                                const revId = String(mark.attrs.revisionId);
-                                const prefix = `tc-${revId}-`;
-                                const match = commentSidebarItems.find((i) =>
-                                  i.id.startsWith(prefix)
-                                );
                                 if (match) {
                                   cursorSidebarItem = match.id;
                                   break;

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3901,13 +3901,15 @@ body { background: white; }
 
                             // Detect comment/tracked-change marks at cursor to open sidebar card.
                             // These marks use inclusive:false, so $from.marks() misses them at
-                            // boundaries. Check nodeAfter/nodeBefore marks for reliable detection.
+                            // boundaries. Collect marks from all sources (nodeAfter, nodeBefore,
+                            // storedMarks) since the OR chain short-circuits on empty arrays.
                             const $from = view.state.selection.$from;
-                            const marks =
-                              view.state.storedMarks ||
-                              $from.nodeAfter?.marks ||
-                              $from.nodeBefore?.marks ||
-                              $from.marks();
+                            const marks = [
+                              ...(view.state.storedMarks ?? []),
+                              ...($from.nodeAfter?.marks ?? []),
+                              ...($from.nodeBefore?.marks ?? []),
+                              ...$from.marks(),
+                            ];
                             let cursorSidebarItem: string | null = null;
                             for (const mark of marks) {
                               if (mark.type.name === 'comment' && mark.attrs.commentId != null) {

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -3903,6 +3903,8 @@ body { background: white; }
                             // These marks use inclusive:false, so $from.marks() misses them at
                             // boundaries. Collect marks from all sources (nodeAfter, nodeBefore,
                             // storedMarks) since the OR chain short-circuits on empty arrays.
+                            // Search commentSidebarItems (always populated) not allSidebarItems
+                            // (which is empty when sidebar is closed) so we can auto-open it.
                             const $from = view.state.selection.$from;
                             const marks = [
                               ...(view.state.storedMarks ?? []),
@@ -3919,11 +3921,13 @@ body { background: white; }
                               if (mark.type.name === 'insertion' && mark.attrs.revisionId != null) {
                                 const revId = String(mark.attrs.revisionId);
                                 const prefix = `tc-${revId}-`;
-                                let match = allSidebarItems.find((i) => i.id.startsWith(prefix));
+                                let match = commentSidebarItems.find((i) =>
+                                  i.id.startsWith(prefix)
+                                );
                                 if (!match && revisionIdAliases) {
                                   const aliasedId = revisionIdAliases.get(revId);
                                   if (aliasedId) {
-                                    match = allSidebarItems.find((i) => i.id === aliasedId);
+                                    match = commentSidebarItems.find((i) => i.id === aliasedId);
                                   }
                                 }
                                 if (match) {
@@ -3934,12 +3938,17 @@ body { background: white; }
                               if (mark.type.name === 'deletion' && mark.attrs.revisionId != null) {
                                 const revId = String(mark.attrs.revisionId);
                                 const prefix = `tc-${revId}-`;
-                                const match = allSidebarItems.find((i) => i.id.startsWith(prefix));
+                                const match = commentSidebarItems.find((i) =>
+                                  i.id.startsWith(prefix)
+                                );
                                 if (match) {
                                   cursorSidebarItem = match.id;
                                   break;
                                 }
                               }
+                            }
+                            if (cursorSidebarItem) {
+                              setShowCommentsSidebar(true);
                             }
                             setExpandedSidebarItem(cursorSidebarItem);
                           } else {

--- a/packages/react/src/components/UnifiedSidebar.tsx
+++ b/packages/react/src/components/UnifiedSidebar.tsx
@@ -21,8 +21,8 @@ export interface UnifiedSidebarProps {
   zoom: number;
   editorContainerRef: React.RefObject<HTMLDivElement | null>;
   onExpandedItemChange?: (itemId: string | null) => void;
-  /** Maps alternate revision IDs to sidebar item IDs (e.g. insertion side of replacements). */
-  revisionIdAliases?: Map<string, string>;
+  /** Controlled: sidebar item to expand based on cursor position. */
+  activeItemId?: string | null;
 }
 
 export function UnifiedSidebar({
@@ -33,10 +33,17 @@ export function UnifiedSidebar({
   zoom,
   editorContainerRef,
   onExpandedItemChange,
-  revisionIdAliases,
+  activeItemId,
 }: UnifiedSidebarProps) {
   const { t } = useTranslation();
   const [expandedItem, setExpandedItem] = useState<string | null>(null);
+
+  // Sync internal state when cursor-driven activeItemId changes
+  useEffect(() => {
+    if (activeItemId !== undefined) {
+      setExpandedItem(activeItemId);
+    }
+  }, [activeItemId]);
 
   // Notify parent when expanded item changes (via effect, not in setState updater)
   useEffect(() => {
@@ -146,52 +153,6 @@ export function UnifiedSidebar({
       observer.disconnect();
     };
   }, [expandedItem]);
-
-  useEffect(() => {
-    const container = editorContainerRef?.current;
-    if (!container) return;
-
-    const pagesEl = container.querySelector('.paged-editor__pages');
-    if (!pagesEl) return;
-
-    const handleDocClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (sidebarRef.current?.contains(target)) return;
-
-      if (pagesEl.contains(target)) {
-        const commentEl = target.closest('[data-comment-id]') as HTMLElement | null;
-        if (commentEl?.dataset.commentId) {
-          setExpandedItem(`comment-${commentEl.dataset.commentId}`);
-          return;
-        }
-        const changeEl =
-          (target.closest('.docx-insertion') as HTMLElement | null) ||
-          (target.closest('.docx-deletion') as HTMLElement | null);
-        if (changeEl?.dataset.revisionId) {
-          const revId = changeEl.dataset.revisionId;
-          const prefix = `tc-${revId}-`;
-          let match = items.find((i) => i.id.startsWith(prefix));
-          // For replacement tracked changes, the insertion part has a different
-          // revisionId than the card. Look up the alias to find the correct card.
-          if (!match && revisionIdAliases) {
-            const aliasedItemId = revisionIdAliases.get(revId);
-            if (aliasedItemId) {
-              match = items.find((i) => i.id === aliasedItemId);
-            }
-          }
-          if (match) {
-            setExpandedItem(match.id);
-            return;
-          }
-        }
-      }
-
-      setExpandedItem(null);
-    };
-
-    container.addEventListener('click', handleDocClick);
-    return () => container.removeEventListener('click', handleDocClick);
-  }, [editorContainerRef, items, revisionIdAliases]);
 
   const getMeasureRef = useCallback((itemId: string): ((el: HTMLDivElement | null) => void) => {
     let fn = measureRefsRef.current.get(itemId);

--- a/packages/react/src/components/UnifiedSidebar.tsx
+++ b/packages/react/src/components/UnifiedSidebar.tsx
@@ -38,6 +38,9 @@ export function UnifiedSidebar({
   const { t } = useTranslation();
   // Fully controlled: parent owns expansion state via activeItemId
   const expandedItem = activeItemId ?? null;
+  // Ref keeps toggleExpand stable so card children don't re-render on every cursor move
+  const expandedItemRef = useRef(expandedItem);
+  expandedItemRef.current = expandedItem;
 
   const [initialPositionsDone, setInitialPositionsDone] = useState(false);
   const cardHeightsRef = useRef<Map<string, number>>(new Map());
@@ -162,9 +165,9 @@ export function UnifiedSidebar({
 
   const toggleExpand = useCallback(
     (itemId: string) => {
-      onExpandedItemChange?.(expandedItem === itemId ? null : itemId);
+      onExpandedItemChange?.(expandedItemRef.current === itemId ? null : itemId);
     },
-    [expandedItem, onExpandedItemChange]
+    [onExpandedItemChange]
   );
 
   if (items.length === 0) return null;

--- a/packages/react/src/components/UnifiedSidebar.tsx
+++ b/packages/react/src/components/UnifiedSidebar.tsx
@@ -36,19 +36,8 @@ export function UnifiedSidebar({
   activeItemId,
 }: UnifiedSidebarProps) {
   const { t } = useTranslation();
-  const [expandedItem, setExpandedItem] = useState<string | null>(null);
-
-  // Sync internal state when cursor-driven activeItemId changes
-  useEffect(() => {
-    if (activeItemId !== undefined) {
-      setExpandedItem(activeItemId);
-    }
-  }, [activeItemId]);
-
-  // Notify parent when expanded item changes (via effect, not in setState updater)
-  useEffect(() => {
-    onExpandedItemChange?.(expandedItem);
-  }, [expandedItem, onExpandedItemChange]);
+  // Fully controlled: parent owns expansion state via activeItemId
+  const expandedItem = activeItemId ?? null;
 
   const [initialPositionsDone, setInitialPositionsDone] = useState(false);
   const cardHeightsRef = useRef<Map<string, number>>(new Map());
@@ -171,9 +160,12 @@ export function UnifiedSidebar({
     return fn;
   }, []);
 
-  const toggleExpand = useCallback((itemId: string) => {
-    setExpandedItem((prev) => (prev === itemId ? null : itemId));
-  }, []);
+  const toggleExpand = useCallback(
+    (itemId: string) => {
+      onExpandedItemChange?.(expandedItem === itemId ? null : itemId);
+    },
+    [expandedItem, onExpandedItemChange]
+  );
 
   if (items.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Replace the DOM click handler in `UnifiedSidebar` with ProseMirror cursor-driven mark detection in `DocxEditor`
- When cursor lands on a `comment`, `insertion`, or `deletion` mark, the matching sidebar card expands automatically
- Also works with keyboard navigation (arrow keys into a mark), not just mouse clicks
- Removes ~46 lines of DOM event handling, replaces `revisionIdAliases` prop with simpler `activeItemId` controlled prop

## Test plan
- [ ] Click on a comment highlight → sidebar card expands
- [ ] Click on a tracked change (insertion/deletion) → sidebar card expands
- [ ] Click on a replacement tracked change (insertion side) → correct card expands
- [ ] Click on normal text → sidebar card collapses
- [ ] Use keyboard to navigate into a comment/tracked change → card expands
- [ ] Click sidebar card toggle to collapse → stays collapsed until cursor moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)