### PR TITLE
feat(core): expose framework-adapter subpaths via exports map

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "packages/agent-use": {
       "name": "@eigenpal/docx-editor-agents",
-      "version": "0.0.31",
+      "version": "0.0.34",
       "dependencies": {
         "docxtemplater": "^3.50.0",
         "jszip": "^3.10.1",
@@ -56,6 +56,9 @@
         "docxtemplater": "^3.50.0",
         "jszip": "^3.10.1",
         "pizzip": "^3.1.7",
+        "xml-js": "^1.6.11",
+      },
+      "devDependencies": {
         "prosemirror-commands": "^1.5.2",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-history": "^1.4.0",
@@ -65,12 +68,22 @@
         "prosemirror-tables": "^1.8.5",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.32.7",
-        "xml-js": "^1.6.11",
+      },
+      "peerDependencies": {
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-history": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.19.4",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.32.7",
       },
     },
     "packages/react": {
       "name": "@eigenpal/docx-js-editor",
-      "version": "0.0.31",
+      "version": "0.0.34",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.6",
         "clsx": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,10 +28,66 @@
       "import": "./dist/mcp.mjs",
       "require": "./dist/mcp.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.mjs",
-      "require": "./dist/*.js"
+    "./prosemirror": {
+      "types": "./dist/prosemirror/index.d.ts",
+      "import": "./dist/prosemirror/index.mjs",
+      "require": "./dist/prosemirror/index.js"
+    },
+    "./prosemirror/extensions": {
+      "types": "./dist/prosemirror/extensions/index.d.ts",
+      "import": "./dist/prosemirror/extensions/index.mjs",
+      "require": "./dist/prosemirror/extensions/index.js"
+    },
+    "./prosemirror/editor.css": "./dist/prosemirror/editor.css",
+    "./layout-engine": {
+      "types": "./dist/layout-engine/index.d.ts",
+      "import": "./dist/layout-engine/index.mjs",
+      "require": "./dist/layout-engine/index.js"
+    },
+    "./layout-painter": {
+      "types": "./dist/layout-painter/index.d.ts",
+      "import": "./dist/layout-painter/index.mjs",
+      "require": "./dist/layout-painter/index.js"
+    },
+    "./layout-bridge/toFlowBlocks": {
+      "types": "./dist/layout-bridge/toFlowBlocks.d.ts",
+      "import": "./dist/layout-bridge/toFlowBlocks.mjs",
+      "require": "./dist/layout-bridge/toFlowBlocks.js"
+    },
+    "./layout-bridge/measuring": {
+      "types": "./dist/layout-bridge/measuring/index.d.ts",
+      "import": "./dist/layout-bridge/measuring/index.mjs",
+      "require": "./dist/layout-bridge/measuring/index.js"
+    },
+    "./layout-bridge/clickToPositionDom": {
+      "types": "./dist/layout-bridge/clickToPositionDom.d.ts",
+      "import": "./dist/layout-bridge/clickToPositionDom.mjs",
+      "require": "./dist/layout-bridge/clickToPositionDom.js"
+    },
+    "./layout-bridge/selectionRects": {
+      "types": "./dist/layout-bridge/selectionRects.d.ts",
+      "import": "./dist/layout-bridge/selectionRects.mjs",
+      "require": "./dist/layout-bridge/selectionRects.js"
+    },
+    "./managers": {
+      "types": "./dist/managers/index.d.ts",
+      "import": "./dist/managers/index.mjs",
+      "require": "./dist/managers/index.js"
+    },
+    "./plugin-api": {
+      "types": "./dist/plugin-api/index.d.ts",
+      "import": "./dist/plugin-api/index.mjs",
+      "require": "./dist/plugin-api/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.mjs",
+      "require": "./dist/types/index.js"
+    },
+    "./utils/textSelection": {
+      "types": "./dist/utils/textSelection.d.ts",
+      "import": "./dist/utils/textSelection.mjs",
+      "require": "./dist/utils/textSelection.js"
     }
   },
   "typesVersions": {
@@ -44,6 +100,42 @@
       ],
       "mcp": [
         "./dist/mcp.d.ts"
+      ],
+      "prosemirror": [
+        "./dist/prosemirror/index.d.ts"
+      ],
+      "prosemirror/extensions": [
+        "./dist/prosemirror/extensions/index.d.ts"
+      ],
+      "layout-engine": [
+        "./dist/layout-engine/index.d.ts"
+      ],
+      "layout-painter": [
+        "./dist/layout-painter/index.d.ts"
+      ],
+      "layout-bridge/toFlowBlocks": [
+        "./dist/layout-bridge/toFlowBlocks.d.ts"
+      ],
+      "layout-bridge/measuring": [
+        "./dist/layout-bridge/measuring/index.d.ts"
+      ],
+      "layout-bridge/clickToPositionDom": [
+        "./dist/layout-bridge/clickToPositionDom.d.ts"
+      ],
+      "layout-bridge/selectionRects": [
+        "./dist/layout-bridge/selectionRects.d.ts"
+      ],
+      "managers": [
+        "./dist/managers/index.d.ts"
+      ],
+      "plugin-api": [
+        "./dist/plugin-api/index.d.ts"
+      ],
+      "types": [
+        "./dist/types/index.d.ts"
+      ],
+      "utils/textSelection": [
+        "./dist/utils/textSelection.d.ts"
       ]
     }
   },
@@ -54,23 +146,36 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/copy-assets.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "docxtemplater": "^3.50.0",
     "jszip": "^3.10.1",
     "pizzip": "^3.1.7",
+    "xml-js": "^1.6.11"
+  },
+  "peerDependencies": {
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-history": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.19.4",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-transform": "^1.10.2",
     "prosemirror-tables": "^1.8.5",
-    "prosemirror-view": "^1.32.7",
-    "xml-js": "^1.6.11"
+    "prosemirror-transform": "^1.10.2",
+    "prosemirror-view": "^1.32.7"
+  },
+  "devDependencies": {
+    "prosemirror-commands": "^1.5.2",
+    "prosemirror-dropcursor": "^1.8.2",
+    "prosemirror-history": "^1.4.0",
+    "prosemirror-keymap": "^1.2.2",
+    "prosemirror-model": "^1.19.4",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-tables": "^1.8.5",
+    "prosemirror-transform": "^1.10.2",
+    "prosemirror-view": "^1.32.7"
   },
   "keywords": [
     "docx",

--- a/packages/core/scripts/copy-assets.mjs
+++ b/packages/core/scripts/copy-assets.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Copy non-JS assets into dist/ after tsup build.
+ * tsup bundles JS/TS only; CSS and similar resources have to be copied
+ * explicitly so they're reachable through the package's subpath exports.
+ */
+import { cp, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+const assets = [
+  { from: 'src/prosemirror/editor.css', to: 'dist/prosemirror/editor.css' },
+];
+
+for (const { from, to } of assets) {
+  const src = resolve(root, from);
+  const dst = resolve(root, to);
+  await mkdir(dirname(dst), { recursive: true });
+  await cp(src, dst);
+  console.log(`[copy-assets] ${from} → ${to}`);
+}

--- a/packages/core/src/layout-painter/index.ts
+++ b/packages/core/src/layout-painter/index.ts
@@ -48,6 +48,7 @@ export {
   TEXTBOX_CLASS_NAMES,
   type RenderContext,
 };
+export type { HeaderFooterContent } from './renderPage';
 
 /**
  * Block lookup entry for painter

--- a/packages/core/src/prosemirror/extensions/ExtensionManager.ts
+++ b/packages/core/src/prosemirror/extensions/ExtensionManager.ts
@@ -49,7 +49,7 @@ export class ExtensionManager {
       throw new Error('ExtensionManager: buildSchema() must be called before initializeRuntime()');
     }
 
-    const ctx: ExtensionContext = { schema: this.schema };
+    const ctx: ExtensionContext = { schema: this.schema, manager: this };
     const allKeyboardShortcuts: KeyboardShortcutMap[] = [];
     const allPlugins: PMPlugin[] = [];
     const allCommands: CommandMap = {};

--- a/packages/core/src/prosemirror/extensions/features/BidiShortcutExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/BidiShortcutExtension.ts
@@ -11,12 +11,12 @@ import { Plugin } from 'prosemirror-state';
 import { createExtension } from '../create';
 import { Priority } from '../types';
 import type { ExtensionRuntime, ExtensionContext } from '../types';
-import { singletonManager } from '../../schema';
 
 export const BidiShortcutExtension = createExtension({
   name: 'bidiShortcut',
   priority: Priority.High,
-  onSchemaReady(_ctx: ExtensionContext): ExtensionRuntime {
+  onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+    const { manager } = ctx;
     return {
       plugins: [
         new Plugin({
@@ -27,7 +27,7 @@ export const BidiShortcutExtension = createExtension({
               const isMod = event.metaKey || event.ctrlKey;
               if (!isMod) return false;
 
-              const cmds = singletonManager.getCommands();
+              const cmds = manager.getCommands();
 
               if (event.code === 'ShiftLeft') {
                 event.preventDefault();

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -13,6 +13,7 @@ import {
   clearTrackedChanges,
   ParagraphChangeTrackerExtension,
 } from './ParagraphChangeTrackerExtension';
+import { ExtensionManager } from '../ExtensionManager';
 
 // Minimal schema with paraId support
 const schema = new Schema({
@@ -41,7 +42,8 @@ const schema = new Schema({
 
 // Get the plugin from the extension
 const ext = ParagraphChangeTrackerExtension();
-const runtime = ext.onSchemaReady({ schema });
+const manager = new ExtensionManager([]);
+const runtime = ext.onSchemaReady({ schema, manager });
 const plugin = runtime.plugins![0];
 
 function createDoc(...paras: Array<{ text: string; paraId?: string }>) {

--- a/packages/core/src/prosemirror/extensions/types.ts
+++ b/packages/core/src/prosemirror/extensions/types.ts
@@ -10,6 +10,7 @@
 
 import type { Schema, NodeSpec, MarkSpec } from 'prosemirror-model';
 import type { Plugin as PMPlugin, Command } from 'prosemirror-state';
+import type { ExtensionManager } from './ExtensionManager';
 
 // ============================================================================
 // PRIORITY
@@ -31,6 +32,14 @@ export const Priority = {
 
 export interface ExtensionContext {
   schema: Schema;
+  /**
+   * The manager that owns this extension. Use this in runtime callbacks
+   * (e.g. `handleKeyDown`) that need to dispatch commands, instead of
+   * reaching back to the `singletonManager` export — the latter forms a
+   * circular import that breaks when the package is consumed as a built
+   * bundle.
+   */
+  manager: ExtensionManager;
 }
 
 export type CommandMap = Record<string, (...args: any[]) => Command>;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,6 +9,21 @@ export default defineConfig([
       headless: 'src/headless.ts',
       'core-plugins': 'src/core-plugins/index.ts',
       mcp: 'src/mcp/index.ts',
+      // Subpath entries — stable public surface at directory-boundary
+      // granularity, so framework adapters outside packages/{react,vue}
+      // can consume internals without reaching into src/.
+      'prosemirror/index': 'src/prosemirror/index.ts',
+      'prosemirror/extensions/index': 'src/prosemirror/extensions/index.ts',
+      'layout-engine/index': 'src/layout-engine/index.ts',
+      'layout-painter/index': 'src/layout-painter/index.ts',
+      'layout-bridge/toFlowBlocks': 'src/layout-bridge/toFlowBlocks.ts',
+      'layout-bridge/measuring/index': 'src/layout-bridge/measuring/index.ts',
+      'layout-bridge/clickToPositionDom': 'src/layout-bridge/clickToPositionDom.ts',
+      'layout-bridge/selectionRects': 'src/layout-bridge/selectionRects.ts',
+      'managers/index': 'src/managers/index.ts',
+      'plugin-api/index': 'src/plugin-api/index.ts',
+      'types/index': 'src/types/index.ts',
+      'utils/textSelection': 'src/utils/textSelection.ts',
     },
     format: ['cjs', 'esm'],
     dts: true,


### PR DESCRIPTION
## Summary

- feat(core): expose framework-adapter subpaths via exports map
Adds explicit subpath exports for internals that framework adapters
(outside packages/{react,vue}) need to consume without reaching into
src/. Replaces the `./*` catch-all with a curated surface at directory
boundaries.
New subpaths:
  ./prosemirror, ./prosemirror/extensions, ./prosemirror/editor.css
  ./layout-engine, ./layout-painter
  ./layout-bridge/{toFlowBlocks,measuring,clickToPositionDom,selectionRects}
  ./managers, ./plugin-api, ./types, ./utils/textSelection
Also:
- tsup.config.ts: add matching entry keys so dist mirrors src layout
- scripts/copy-assets.mjs: copy editor.css into dist/ post-build
- layout-painter: re-export HeaderFooterContent type
- Move prosemirror-* from dependencies to peerDependencies: consumers
  own the PM version, which avoids duplicate PM copies in consumer
  bundles (previously needed resolve.dedupe workarounds).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes
- [x] `bun run build` succeeds
