### PR TITLE
fix(editor): prevent caret-left jumps and place cursor at paraId end

### DIFF
--- a/e2e/tests/scroll-to-paragraph.spec.ts
+++ b/e2e/tests/scroll-to-paragraph.spec.ts
@@ -59,6 +59,29 @@ test.describe('Scroll to paragraph / position (E2E)', () => {
     await waitPaintedInViewport(page, start);
   });
 
+  test('scrollToParaId places the cursor at the end of the target paragraph', async ({ page }) => {
+    const firstId = await page.evaluate(
+      () => window.__DOCX_EDITOR_E2E__?.getFirstTextblockParaId() ?? null
+    );
+    test.skip(!firstId, 'Demo document has no paragraph paraIds');
+
+    const expectedEnd = await page.evaluate(
+      (id) => window.__DOCX_EDITOR_E2E__?.getTextblockEndForParaId(id) ?? null,
+      firstId
+    );
+    expect(expectedEnd).not.toBeNull();
+
+    await page.evaluate((id) => {
+      window.__DOCX_EDITOR_E2E__?.scrollToParaId(id);
+    }, firstId);
+
+    await page.waitForFunction(
+      (pos) => window.__DOCX_EDITOR_E2E__?.getSelectionAnchor() === pos,
+      expectedEnd,
+      { timeout: 20000 }
+    );
+  });
+
   test('long jump: scroll to last paraId after scrolling to first', async ({ page }) => {
     const firstId = await page.evaluate(
       () => window.__DOCX_EDITOR_E2E__?.getFirstTextblockParaId() ?? null
@@ -108,5 +131,17 @@ test.describe('Scroll to paragraph / position (E2E)', () => {
     }, pos);
 
     await waitPaintedInViewport(page, pos);
+  });
+
+  test('hidden ProseMirror is portaled outside the paged scroller', async ({ page }) => {
+    const isPortaled = await page.evaluate(() => {
+      const hiddenPm = document.querySelector('.paged-editor__hidden-pm');
+      const pages = document.querySelector('.paged-editor__pages');
+      return (
+        hiddenPm != null && hiddenPm.parentElement === document.body && !pages?.contains(hiddenPm)
+      );
+    });
+
+    expect(isPortaled).toBe(true);
   });
 });

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -112,6 +112,18 @@ export function App() {
         if (!state || !paraId) return null;
         return findStartPosForParaId(state.doc, paraId);
       },
+      getSelectionAnchor: () => {
+        const state = editorRef.current?.getEditorRef()?.getState?.();
+        return state?.selection.anchor ?? null;
+      },
+      getTextblockEndForParaId: (paraId: string) => {
+        const state = editorRef.current?.getEditorRef()?.getState?.();
+        if (!state || !paraId) return null;
+        const start = findStartPosForParaId(state.doc, paraId);
+        if (start == null) return null;
+        const node = state.doc.nodeAt(start);
+        return node?.isTextblock === true ? start + 1 + node.content.size : null;
+      },
       getFirstTextblockParaId: () => {
         const view = editorRef.current?.getEditorRef()?.getView?.();
         if (!view) return null;

--- a/examples/vite/src/window-e2e.d.ts
+++ b/examples/vite/src/window-e2e.d.ts
@@ -3,6 +3,8 @@ declare global {
   interface Window {
     __DOCX_EDITOR_E2E__?: {
       getPmStartForParaId: (paraId: string) => number | null;
+      getSelectionAnchor: () => number | null;
+      getTextblockEndForParaId: (paraId: string) => number | null;
       getFirstTextblockParaId: () => string | null;
       getLastTextblockParaId: () => string | null;
       scrollToParaId: (paraId: string) => boolean;

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -17,6 +17,7 @@
 
 import { useRef, useEffect, useCallback, useImperativeHandle, forwardRef, memo } from 'react';
 import type { CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import {
   EditorState,
   Transaction,
@@ -317,6 +318,8 @@ const HiddenProseMirrorComponent = forwardRef<HiddenProseMirrorRef, HiddenProseM
         handleKeyDown: (view: EditorView, event: KeyboardEvent): boolean => {
           return onKeyDownRef.current?.(view, event) ?? false;
         },
+        // Paginated layer owns scroll; never let PM scroll the viewport / ancestors.
+        handleScrollToSelection: () => true,
         // Prevent focus handling from interfering with visual layer
         handleDOMEvents: {
           focus: () => {
@@ -519,7 +522,7 @@ const HiddenProseMirrorComponent = forwardRef<HiddenProseMirrorRef, HiddenProseM
     // Render
     // ========================================================================
 
-    return (
+    const host = (
       <div
         ref={hostRef}
         className="paged-editor__hidden-pm"
@@ -530,6 +533,15 @@ const HiddenProseMirrorComponent = forwardRef<HiddenProseMirrorRef, HiddenProseM
         // DO NOT set aria-hidden - this editor provides semantic structure
       />
     );
+
+    // Mount off-DOM from the paginated scroll container. Otherwise ProseMirror's
+    // preserve-mode selection updates (storeScrollPos / resetScrollStack) walk
+    // ancestors and can clobber the document scroller — e.g. ArrowLeft after
+    // scrollToParaId. See prosemirror-view updateStateInner (scroll === "preserve").
+    const browserDoc = globalThis.document;
+    const portalTarget =
+      browserDoc && 'body' in browserDoc && browserDoc.body != null ? browserDoc.body : null;
+    return portalTarget ? createPortal(host, portalTarget) : host;
   }
 );
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -3033,7 +3033,11 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         // a superseding scroll cancels this too.
         const signal = scrollAbortRef.current?.signal;
         if (!signal) return true;
-        const inner = Math.min(startPos + 1, state.doc.content.size);
+        const targetNode = state.doc.nodeAt(startPos);
+        const inner =
+          targetNode?.isTextblock === true
+            ? Math.min(startPos + 1 + targetNode.content.size, state.doc.content.size)
+            : Math.min(startPos + 1, state.doc.content.size);
         runAfterPaint(() => {
           if (!hiddenPMRef.current) return;
           hiddenPMRef.current.setSelection(inner);


### PR DESCRIPTION
## Summary
- Fixes #301.
- Prevent ProseMirror preserve-scroll handling from moving the paged editor after `scrollToParaId`.
- Place the cursor at the end of the target paragraph when navigating by `paraId`, instead of the paragraph start.
- Add E2E coverage for paraId cursor placement and hidden ProseMirror portal mounting.

## Test plan
- `bun run typecheck`
- `bun run build`
- `bun test`