### PR TITLE
fix(core): remap step coords in paragraphChangeTracker apply

### DIFF
--- a/.changeset/paragraph-change-tracker-step-coords.md
+++ b/.changeset/paragraph-change-tracker-step-coords.md
@@ -1,0 +1,22 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix crash when accepting a tracked replacement.
+
+The `paragraphChangeTracker` plugin walked `tr.steps` using each step's raw
+`from`/`to`/`pos` against `tr.doc` (the final doc after every step has been
+applied). Those coords are valid only in the doc as it was _when that step
+ran_, so a later doc-shrinking step could leave the earlier step's coords
+past the final doc end and crash `Fragment.nodesBetween` on
+`undefined.nodeSize`.
+
+Concretely: `acceptChange` emits `[RemoveMarkStep, ReplaceStep]` when the
+range contains both an `insertion` mark and a `deletion` (a tracked
+replace). The replace shrinks the doc, the mark step's `to` becomes
+invalid in `tr.doc`, and the editor crashes.
+
+Remap each step's coords through `tr.mapping.slice(stepIndex + 1)` before
+using them with `tr.doc`, and skip steps whose range was fully consumed by
+a later deletion. Adds a regression test reproducing the
+accept-tracked-replacement crash shape.

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { Schema } from 'prosemirror-model';
+import { Schema, Slice } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';
-import { AddMarkStep, RemoveMarkStep } from 'prosemirror-transform';
+import { AddMarkStep, RemoveMarkStep, ReplaceStep } from 'prosemirror-transform';
 import {
   getChangedParagraphIds,
   hasStructuralChanges,
@@ -106,6 +106,26 @@ describe('ParagraphChangeTrackerExtension', () => {
       state = state.apply(tr);
 
       expect(getChangedParagraphIds(state).has('P1')).toBe(true);
+    });
+
+    test('does not crash when a RemoveMarkStep is followed by a shrinking ReplaceStep', () => {
+      let state = createState([
+        { text: 'AAAA', paraId: 'P1' },
+        { text: 'BBBB', paraId: 'P2' },
+      ]);
+      const bold = schema.marks.bold.create();
+      // Mark all of paragraph 2's text (positions 7..11).
+      state = state.apply(state.tr.step(new AddMarkStep(7, 11, bold)));
+
+      // Build a single transaction with the crash-shape pair.
+      const tr = state.tr;
+      tr.step(new RemoveMarkStep(7, 11, bold));
+      tr.step(new ReplaceStep(1, 5, Slice.empty));
+      // Should not throw.
+      state = state.apply(tr);
+
+      expect(getChangedParagraphIds(state).has('P1')).toBe(true);
+      expect(getChangedParagraphIds(state).has('P2')).toBe(true);
     });
   });
 

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -149,14 +149,27 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
           newState.structuralChange = true;
         }
 
-        // Track which paragraphs were affected by each step
-        for (const step of tr.steps) {
+        // Track which paragraphs were affected by each step.
+        //
+        // Each step's `from`/`to`/`pos` are valid in the doc as it was *when
+        // that step ran*, not in `tr.doc` (the final doc after every step).
+        // We must remap them through the mapping of all subsequent steps
+        // before using them with `tr.doc.nodesBetween` / `tr.doc.nodeAt`,
+        // otherwise a later doc-shrinking step can leave the coords past
+        // the final doc end, crashing `Fragment.nodesBetween` on
+        // `undefined.nodeSize`.
+        for (let stepIndex = 0; stepIndex < tr.steps.length; stepIndex++) {
+          const step = tr.steps[stepIndex];
+          const remap = tr.mapping.slice(stepIndex + 1);
+
           if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
-            const { ids, hasUntracked } = collectAffectedParaIdsFromMarkLikeStep(
-              tr.doc,
-              step.from,
-              step.to
-            );
+            const from = remap.map(step.from, 1);
+            const to = remap.map(step.to, -1);
+            if (to <= from) {
+              // Range fully covered by a later deletion; nothing to track.
+              continue;
+            }
+            const { ids, hasUntracked } = collectAffectedParaIdsFromMarkLikeStep(tr.doc, from, to);
             for (const id of ids) {
               newState.changedParaIds.add(id);
             }
@@ -167,9 +180,13 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
           }
 
           if (step instanceof AddNodeMarkStep || step instanceof RemoveNodeMarkStep) {
-            const pos = step.pos;
+            const pos = remap.map(step.pos, 1);
             const node = tr.doc.nodeAt(pos);
-            const end = node ? pos + node.nodeSize : pos + 1;
+            if (!node) {
+              // Target node was deleted by a later step.
+              continue;
+            }
+            const end = pos + node.nodeSize;
             const { ids, hasUntracked } = collectAffectedParaIds(tr.doc, pos, end);
             for (const id of ids) {
               newState.changedParaIds.add(id);
@@ -180,9 +197,14 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
             continue;
           }
 
+          // ReplaceStep / ReplaceAroundStep emit (newStart, newEnd) coords
+          // in the doc *after this step*. Remap those forward to `tr.doc`.
           const stepMap = step.getMap();
           stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
-            const { ids, hasUntracked } = collectAffectedParaIds(tr.doc, newStart, newEnd);
+            const from = remap.map(newStart, 1);
+            const to = remap.map(newEnd, -1);
+            if (to < from) return;
+            const { ids, hasUntracked } = collectAffectedParaIds(tr.doc, from, to);
             for (const id of ids) {
               newState.changedParaIds.add(id);
             }


### PR DESCRIPTION
## Summary

Fixes a crash when accepting a tracked replacement (an insertion mark adjacent to a deletion) in the editor.

The `paragraphChangeTracker` plugin walks `tr.steps` using each step's raw `from`/`to`/`pos` against `tr.doc` (the final doc after every step has been applied). Those coords are valid only in the doc as it was *when that step ran*, so a later doc-shrinking step could leave the earlier step's coords past the final doc end and crash `Fragment.nodesBetween` on \`undefined.nodeSize\`.

## Reproducer

1. Switch the editor to suggesting mode (track changes on).
2. Select a word and type a replacement (creates a tracked deletion + insertion in one shot).
3. Click **Accept** on that change in the gutter.
4. Editor crashes.

\`acceptChange\` (in \`commands/comments.ts\`) emits exactly this pattern when the range contains both an \`insertion\` mark and a \`deletion\`:

\`\`\`js
tr.removeMark(rangeFrom, rangeTo, keepType);  // step A: mark step (no shift)
tr.delete(range.from, range.to);              // step B: shrinks doc
\`\`\`

Step A's \`to\` is recorded against the original doc. Step B then shrinks the doc. When the plugin walks the steps with \`tr.doc\`, step A's \`to\` lies past the final doc end → crash.

## Fix

Remap each step's coords through \`tr.mapping.slice(stepIndex + 1)\` before using them with \`tr.doc\`, and skip steps whose range was fully consumed by a later deletion. Same approach applied to \`AddNodeMarkStep\`/\`RemoveNodeMarkStep\` (uses \`step.pos\`) and \`ReplaceStep\`/\`ReplaceAroundStep\` (via \`step.getMap().forEach\`).

## Test

Adds a regression test in \`ParagraphChangeTrackerExtension.test.ts\` that reproduces the accept-tracked-replacement crash shape: an \`AddMarkStep\` against the end of the doc followed by a \`ReplaceStep\` deleting earlier content, in a single transaction. Without the fix this throws; with the fix both affected paraIds are correctly recorded as changed.

## Why short docs surface this more easily

The crash needs the earlier step's \`to\` to land *past* the final doc size after the later deletion. Short docs put every position close to the end, so almost any tracked replace triggers it. Larger docs only crash when the change happens near the end.

## Behavior change for non-crash cases

This also fixes a silent correctness bug: in non-crash multi-step transactions, stale positions could land on the wrong paragraph and add the wrong \`paraId\` to \`changedParaIds\`. After this fix, \`changedParaIds\` correctly reflects the affected paragraphs, which is the contract callers (e.g. selective save) rely on.

## Validation

- \`bun test packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts\` — all 15 pass (14 existing + 1 new regression).
- \`bun run typecheck\` — clean across all workspaces.