### PR TITLE
feat: allow disabling editor find shortcuts

### DIFF
--- a/.changeset/disable-find-replace-shortcuts.md
+++ b/.changeset/disable-find-replace-shortcuts.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add `disableFindReplaceShortcuts` to `DocxEditor` so host apps can let the browser handle native Cmd/Ctrl+F and Cmd/Ctrl+H shortcuts.

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -2,45 +2,46 @@
 
 ## Props
 
-| Prop                   | Type                                        | Default     | Description                                                                            |
-| ---------------------- | ------------------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
-| `documentBuffer`       | `ArrayBuffer \| Uint8Array \| Blob \| File` | —           | `.docx` file contents to load                                                          |
-| `document`             | `Document`                                  | —           | Pre-parsed document (alternative to buffer)                                            |
-| `author`               | `string`                                    | `'User'`    | Author name for comments and track changes                                             |
-| `mode`                 | `'editing' \| 'suggesting' \| 'viewing'`    | `'editing'` | Editor mode — editing, suggesting (track changes), or viewing (read-only with toolbar) |
-| `onModeChange`         | `(mode: EditorMode) => void`                | —           | Called when the user changes the editing mode                                          |
-| `readOnly`             | `boolean`                                   | `false`     | Read-only preview (hides toolbar, rulers, panel)                                       |
-| `externalContent`      | `boolean`                                   | `false`     | Treat `document` as schema seed only — content is provided externally (e.g. Yjs)       |
-| `showToolbar`          | `boolean`                                   | `true`      | Show formatting toolbar                                                                |
-| `showRuler`            | `boolean`                                   | `false`     | Show horizontal & vertical rulers                                                      |
-| `rulerUnit`            | `'inch' \| 'cm'`                            | `'inch'`    | Unit for ruler display                                                                 |
-| `showZoomControl`      | `boolean`                                   | `true`      | Show zoom controls in toolbar                                                          |
-| `showPrintButton`      | `boolean`                                   | `true`      | Show print button in toolbar                                                           |
-| `showOutline`          | `boolean`                                   | `false`     | Show document outline sidebar (table of contents)                                      |
-| `showMarginGuides`     | `boolean`                                   | `false`     | Show page margin guide boundaries                                                      |
-| `marginGuideColor`     | `string`                                    | `'#c0c0c0'` | Color for margin guides                                                                |
-| `initialZoom`          | `number`                                    | `1.0`       | Initial zoom level                                                                     |
-| `theme`                | `Theme \| null`                             | —           | Theme for styling                                                                      |
-| `toolbarExtra`         | `ReactNode`                                 | —           | Custom toolbar items appended to the toolbar                                           |
-| `placeholder`          | `ReactNode`                                 | —           | Placeholder when no document is loaded                                                 |
-| `loadingIndicator`     | `ReactNode`                                 | —           | Custom loading indicator                                                               |
-| `className`            | `string`                                    | —           | Additional CSS class name                                                              |
-| `style`                | `CSSProperties`                             | —           | Additional inline styles                                                               |
-| `onChange`             | `(doc: Document) => void`                   | —           | Called on document change                                                              |
-| `onSave`               | `(buffer: ArrayBuffer) => void`             | —           | Called on save                                                                         |
-| `onError`              | `(error: Error) => void`                    | —           | Called on error                                                                        |
-| `onSelectionChange`    | `(state: SelectionState \| null) => void`   | —           | Called on selection change                                                             |
-| `onFontsLoaded`        | `() => void`                                | —           | Called when fonts finish loading                                                       |
-| `onPrint`              | `() => void`                                | —           | Called when print is triggered                                                         |
-| `onCopy`               | `() => void`                                | —           | Called when content is copied                                                          |
-| `onCut`                | `() => void`                                | —           | Called when content is cut                                                             |
-| `onPaste`              | `() => void`                                | —           | Called when content is pasted                                                          |
-| `renderLogo`           | `() => ReactNode`                           | —           | Custom logo in the title bar                                                           |
-| `documentName`         | `string`                                    | —           | Editable document name in the title bar                                                |
-| `onDocumentNameChange` | `(name: string) => void`                    | —           | Called when the user edits the document name                                           |
-| `renderTitleBarRight`  | `() => ReactNode`                           | —           | Custom right-side actions in the title bar                                             |
-| `comments`             | `Comment[]`                                 | —           | Controlled comments. Pair with `onCommentsChange` to sync over Yjs / Liveblocks / etc. |
-| `onCommentsChange`     | `(comments: Comment[]) => void`             | —           | Fires whenever the comments array changes (controlled mode)                            |
+| Prop                          | Type                                        | Default     | Description                                                                                            |
+| ----------------------------- | ------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `documentBuffer`              | `ArrayBuffer \| Uint8Array \| Blob \| File` | —           | `.docx` file contents to load                                                                          |
+| `document`                    | `Document`                                  | —           | Pre-parsed document (alternative to buffer)                                                            |
+| `author`                      | `string`                                    | `'User'`    | Author name for comments and track changes                                                             |
+| `mode`                        | `'editing' \| 'suggesting' \| 'viewing'`    | `'editing'` | Editor mode — editing, suggesting (track changes), or viewing (read-only with toolbar)                 |
+| `onModeChange`                | `(mode: EditorMode) => void`                | —           | Called when the user changes the editing mode                                                          |
+| `readOnly`                    | `boolean`                                   | `false`     | Read-only preview (hides toolbar, rulers, panel)                                                       |
+| `externalContent`             | `boolean`                                   | `false`     | Treat `document` as schema seed only — content is provided externally (e.g. Yjs)                       |
+| `showToolbar`                 | `boolean`                                   | `true`      | Show formatting toolbar                                                                                |
+| `showRuler`                   | `boolean`                                   | `false`     | Show horizontal & vertical rulers                                                                      |
+| `rulerUnit`                   | `'inch' \| 'cm'`                            | `'inch'`    | Unit for ruler display                                                                                 |
+| `showZoomControl`             | `boolean`                                   | `true`      | Show zoom controls in toolbar                                                                          |
+| `showPrintButton`             | `boolean`                                   | `true`      | Show print button in toolbar                                                                           |
+| `showOutline`                 | `boolean`                                   | `false`     | Show document outline sidebar (table of contents)                                                      |
+| `showMarginGuides`            | `boolean`                                   | `false`     | Show page margin guide boundaries                                                                      |
+| `marginGuideColor`            | `string`                                    | `'#c0c0c0'` | Color for margin guides                                                                                |
+| `initialZoom`                 | `number`                                    | `1.0`       | Initial zoom level                                                                                     |
+| `theme`                       | `Theme \| null`                             | —           | Theme for styling                                                                                      |
+| `disableFindReplaceShortcuts` | `boolean`                                   | `false`     | Let the browser or host app handle Cmd/Ctrl+F and Cmd/Ctrl+H instead of opening the editor find dialog |
+| `toolbarExtra`                | `ReactNode`                                 | —           | Custom toolbar items appended to the toolbar                                                           |
+| `placeholder`                 | `ReactNode`                                 | —           | Placeholder when no document is loaded                                                                 |
+| `loadingIndicator`            | `ReactNode`                                 | —           | Custom loading indicator                                                                               |
+| `className`                   | `string`                                    | —           | Additional CSS class name                                                                              |
+| `style`                       | `CSSProperties`                             | —           | Additional inline styles                                                                               |
+| `onChange`                    | `(doc: Document) => void`                   | —           | Called on document change                                                                              |
+| `onSave`                      | `(buffer: ArrayBuffer) => void`             | —           | Called on save                                                                                         |
+| `onError`                     | `(error: Error) => void`                    | —           | Called on error                                                                                        |
+| `onSelectionChange`           | `(state: SelectionState \| null) => void`   | —           | Called on selection change                                                                             |
+| `onFontsLoaded`               | `() => void`                                | —           | Called when fonts finish loading                                                                       |
+| `onPrint`                     | `() => void`                                | —           | Called when print is triggered                                                                         |
+| `onCopy`                      | `() => void`                                | —           | Called when content is copied                                                                          |
+| `onCut`                       | `() => void`                                | —           | Called when content is cut                                                                             |
+| `onPaste`                     | `() => void`                                | —           | Called when content is pasted                                                                          |
+| `renderLogo`                  | `() => ReactNode`                           | —           | Custom logo in the title bar                                                                           |
+| `documentName`                | `string`                                    | —           | Editable document name in the title bar                                                                |
+| `onDocumentNameChange`        | `(name: string) => void`                    | —           | Called when the user edits the document name                                                           |
+| `renderTitleBarRight`         | `() => ReactNode`                           | —           | Custom right-side actions in the title bar                                                             |
+| `comments`                    | `Comment[]`                                 | —           | Controlled comments. Pair with `onCommentsChange` to sync over Yjs / Liveblocks / etc.                 |
+| `onCommentsChange`            | `(comments: Comment[]) => void`             | —           | Fires whenever the comments array changes (controlled mode)                                            |
 
 Source: [`DocxEditorProps`](../packages/react/src/components/DocxEditor.tsx)
 
@@ -63,6 +64,16 @@ Use `readOnly` for a preview-only viewer. This disables editing, caret, and sele
 
 ```tsx
 <DocxEditor documentBuffer={file} readOnly />
+```
+
+## Native Browser Find
+
+By default, `DocxEditor` intercepts Cmd/Ctrl+F and Cmd/Ctrl+H to open its
+find/replace dialog. Set `disableFindReplaceShortcuts` when the surrounding app
+should keep browser-native find or route those shortcuts itself.
+
+```tsx
+<DocxEditor documentBuffer={file} disableFindReplaceShortcuts />
 ```
 
 ## External Content (Yjs and other live sources)

--- a/e2e/tests/find-replace-shortcuts.spec.ts
+++ b/e2e/tests/find-replace-shortcuts.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+function findShortcut(): string {
+  return process.platform === 'darwin' ? 'Meta+f' : 'Control+f';
+}
+
+test.describe('Find/replace shortcuts', () => {
+  test('opens editor find by default', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+
+    await page.keyboard.press(findShortcut());
+
+    await editor.findReplaceDialog.waitFor();
+  });
+
+  test('can leave native browser find shortcut alone', async ({ page }) => {
+    await page.goto('/?e2e=1&disableFindReplaceShortcuts=1');
+    const editor = new EditorPage(page);
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+
+    await page.keyboard.press(findShortcut());
+
+    await expect(editor.findReplaceDialog).toHaveCount(0);
+  });
+});

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -93,6 +93,10 @@ export function App() {
   const [documentBuffer, setDocumentBuffer] = useState<ArrayBuffer | null>(null);
   const [fileName, setFileName] = useState<string>('docx-editor-demo.docx');
   const [status, setStatus] = useState<string>('');
+  const disableFindReplaceShortcuts = useMemo(
+    () => new URLSearchParams(window.location.search).get('disableFindReplaceShortcuts') === '1',
+    []
+  );
 
   const { zoom: autoZoom, isMobile } = useResponsiveLayout();
 
@@ -328,6 +332,7 @@ export function App() {
           showRuler={!isMobile}
           showZoomControl={true}
           initialZoom={autoZoom}
+          disableFindReplaceShortcuts={disableFindReplaceShortcuts}
           renderLogo={renderLogo}
           documentName={fileName}
           onDocumentNameChange={setFileName}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -283,6 +283,11 @@ export interface DocxEditorProps {
   initialZoom?: number;
   /** Whether the editor is read-only. When true, hides toolbar and rulers */
   readOnly?: boolean;
+  /**
+   * When true, the editor does not intercept Cmd/Ctrl+F or Cmd/Ctrl+H.
+   * This lets the browser or host app handle native find/history shortcuts.
+   */
+  disableFindReplaceShortcuts?: boolean;
   /** Custom toolbar actions */
   toolbarExtra?: ReactNode;
   /** Additional CSS class name */
@@ -1048,6 +1053,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     rulerUnit = 'inch',
     initialZoom = 1.0,
     readOnly: readOnlyProp = false,
+    disableFindReplaceShortcuts = false,
     toolbarExtra,
     className = '',
     style,
@@ -1922,12 +1928,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
       if (cmdOrCtrl && !e.shiftKey && !e.altKey) {
         if (e.key.toLowerCase() === 'f') {
+          if (disableFindReplaceShortcuts) return;
           e.preventDefault();
           // Get selected text if any
           const selection = window.getSelection();
           const selectedText = selection && !selection.isCollapsed ? selection.toString() : '';
           findReplace.openFind(selectedText);
         } else if (e.key.toLowerCase() === 'h') {
+          if (disableFindReplaceShortcuts) return;
           e.preventDefault();
           // Get selected text if any
           const selection = window.getSelection();
@@ -1958,7 +1966,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [findReplace, hyperlinkDialog, tableSelection]);
+  }, [disableFindReplaceShortcuts, findReplace, hyperlinkDialog, tableSelection]);
 
   // Handle table insert from toolbar
   const handleInsertTable = useCallback(


### PR DESCRIPTION
First off, thanks for creating and maintaining this library. 

Based on https://github.com/eigenpal/docx-editor/issues/321 I too am noticing that the find function is in need of some love. I tried repairing it myself, but the fixes appear to be non-trivial. 

I'll say that not only does the find function take-over the browser's entire Cmd/Ctrl+F, it doesn't highlight correctly, nor scroll the docx overflow-y container. So just introducing this way to shut off the find function. 

## Summary

- Add `disableFindReplaceShortcuts` to `DocxEditor`.
- Keep the current editor find/replace shortcut behavior by default.
- When enabled, Cmd/Ctrl+F and Cmd/Ctrl+H are not intercepted so the browser or host app can handle find/history behavior.
- Add demo/E2E wiring for `?disableFindReplaceShortcuts=1` and Playwright coverage for both enabled and default shortcut behavior.
- Document the prop in `docs/PROPS.md` with a browser-native find usage example.
- Add a minor changeset for the new public `DocxEditor` prop.

## Validation

- `npx --yes bun run typecheck`
- `npx --yes bun run lint` (passes with existing warnings)
- Browser smoke against the Vite demo on `5175`: default mode opens editor find, disabled mode leaves Cmd/Ctrl+F alone while the editor is focused.

