### PR TITLE
Fix header/footer table render and editor parity

### DIFF
--- a/.changeset/green-eels-wonder.md
+++ b/.changeset/green-eels-wonder.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix header/footer table parity issues in paged render and inline editing, including header recreation after removal.

--- a/e2e/tests/hf-toolbar-and-zindex.spec.ts
+++ b/e2e/tests/hf-toolbar-and-zindex.spec.ts
@@ -6,6 +6,41 @@ const FIXTURE = 'fixtures/header-with-table.docx';
 test.describe.configure({ mode: 'serial' });
 
 test.describe('HF inline editor: toolbar + context menu + z-index (#384, #385)', () => {
+  test('removing a header still allows recreating it from the blank header area', async ({
+    page,
+  }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+
+    await page.locator('input[type="file"][accept=".docx"]').setInputFiles(`e2e/${FIXTURE}`);
+    await page.waitForSelector('.paged-editor__pages');
+    await page.waitForSelector('[data-page-number]');
+    await expect(page.locator('.layout-page-header [data-from-row]')).toHaveCount(1, {
+      timeout: 15000,
+    });
+
+    await page.locator('.layout-page-header').first().dblclick();
+    await page.locator('.hf-inline-editor').waitFor();
+
+    await page
+      .getByRole('button', { name: /options/i })
+      .last()
+      .click();
+    await page
+      .getByRole('button', { name: /remove.*header/i })
+      .last()
+      .click();
+
+    await expect(page.locator('.hf-inline-editor')).toHaveCount(0);
+    const blankHeader = page.locator('.layout-page-header').first();
+    await expect(blankHeader).toBeVisible();
+
+    await blankHeader.dblclick({ position: { x: 20, y: 10 } });
+    await expect(page.locator('.hf-inline-editor')).toHaveCount(1);
+    await expect(page.locator('.hf-inline-editor .ProseMirror')).toBeVisible();
+  });
+
   test('clicking a header table cell shows the Table toolbar group (#384)', async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.goto();

--- a/packages/core/src/layout-bridge/__tests__/normalizeHeaderFooterMeasureBlocks.test.ts
+++ b/packages/core/src/layout-bridge/__tests__/normalizeHeaderFooterMeasureBlocks.test.ts
@@ -73,6 +73,74 @@ describe('#380 — strip inherited spacing, keep inline-explicit spacing', () =>
     const [out] = normalizeHeaderFooterMeasureBlocks([t]);
     expect(out).toBe(t);
   });
+
+  test('inherited spacing is zeroed inside table cell paragraphs too', () => {
+    const t = {
+      ...table(),
+      rows: [
+        {
+          id: 'r1',
+          cells: [
+            {
+              id: 'c1',
+              blocks: [
+                paragraph({
+                  id: 'nested',
+                  attrs: {
+                    spacing: { before: 120, after: 160 },
+                    spacingExplicit: { before: true },
+                  },
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    } satisfies TableBlock;
+
+    const [out] = normalizeHeaderFooterMeasureBlocks([t]) as [TableBlock];
+    const nested = out.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
+    expect(nested.attrs?.spacing?.before).toBe(120);
+    expect(nested.attrs?.spacing?.after).toBeUndefined();
+  });
+
+  test('anchored image runs inside table-cell paragraphs are preserved', () => {
+    const anchoredImage = {
+      kind: 'image' as const,
+      src: 'logo.png',
+      width: 24,
+      height: 24,
+      position: {
+        horizontal: { relativeTo: 'column', posOffset: 0 },
+        vertical: { relativeTo: 'paragraph', posOffset: 0 },
+      },
+    };
+
+    const t = {
+      ...table(),
+      rows: [
+        {
+          id: 'r1',
+          cells: [
+            {
+              id: 'c1',
+              blocks: [
+                paragraph({
+                  id: 'nested-img',
+                  runs: [anchoredImage],
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    } satisfies TableBlock;
+
+    const [out] = normalizeHeaderFooterMeasureBlocks([t]) as [TableBlock];
+    const nested = out.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
+    expect(nested.runs).toHaveLength(1);
+    expect(nested.runs[0]).toEqual(anchoredImage);
+  });
 });
 
 describe('#381 — trailing empty paragraph after a table is zero-height', () => {

--- a/packages/core/src/layout-bridge/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/headerFooterLayout.ts
@@ -131,7 +131,9 @@ function normalizeTableBlock(block: TableBlock): TableBlock {
     let rowChanged = false;
     const cells = row.cells.map((cell) => {
       const normalizedBlocks = normalizeFlowBlockArray(cell.blocks);
-      const cellChanged = normalizedBlocks.some((normalizedBlock, idx) => normalizedBlock !== cell.blocks[idx]);
+      const cellChanged = normalizedBlocks.some(
+        (normalizedBlock, idx) => normalizedBlock !== cell.blocks[idx]
+      );
       if (!cellChanged) return cell;
       rowChanged = true;
       return { ...cell, blocks: normalizedBlocks };
@@ -296,7 +298,12 @@ export function convertHeaderFooterToContent(
     if (m.kind === 'textBox') return h + m.height;
     return h;
   }, 0);
-  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(blocks, measures, totalHeight, metrics);
+  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(
+    blocks,
+    measures,
+    totalHeight,
+    metrics
+  );
 
   return {
     blocks: blocksForMeasure,

--- a/packages/core/src/layout-bridge/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/headerFooterLayout.ts
@@ -11,14 +11,13 @@
  *     → measureBlocks (caller-supplied, Canvas-aware)
  *     → HeaderFooterContent (blocks, measures, height, visualTop/Bottom)
  *
- * The render side uses the ORIGINAL block list (full data: floating images,
- * inherited spacing). Measurement uses a normalized copy from
- * {@link normalizeHeaderFooterMeasureBlocks} that drops things Word does
- * not visually account for in HF height (floating images, style-inherited
- * spacing) and zeroes the canonical trailing-empty-paragraph-after-table.
+ * The render side uses the normalized block list so paint and measurement stay
+ * in lockstep. Visual-bounds calculation still inspects the original block
+ * list because floating images can paint above/below the nominal flow box even
+ * when they do not contribute to flow height.
  */
 
-import type { FlowBlock, ImageRun, Measure, PageMargins, Run } from '../layout-engine/types';
+import type { FlowBlock, ImageRun, Measure, PageMargins, TableBlock } from '../layout-engine/types';
 import type { HeaderFooter, StyleDefinitions, Theme } from '../types/document';
 import type { HeaderFooterContent } from '../layout-painter/renderPage';
 import { headerFooterToProseDoc } from '../prosemirror/conversion/toProseDoc';
@@ -40,21 +39,17 @@ export type HeaderFooterMetrics = {
 // 2. Measurement-time block normalization
 // ============================================================================
 //
-// Two transforms are applied to the FlowBlock list before measurement:
+// Two transforms are applied to the FlowBlock list before measurement/render:
 //
-// 1. **Drop anchored / floating images** (#358) — they're positioned
-//    absolutely at page level and don't contribute to in-flow paragraph
-//    height. The measurement copy renders only the inline runs.
-//
-// 2. **Strip style-inherited paragraph spacing** (#380) — Word visibly
+// 1. **Strip style-inherited paragraph spacing** (#380) — Word visibly
 //    does NOT honor inherited `spaceBefore` / `spaceAfter` (e.g. Normal's
 //    default 8pt-after) inside the HF text frame. Inline `<w:spacing>`
 //    set explicitly on the HF paragraph IS honored. The parser flags
 //    inline spacing via `spacingExplicit.before` / `.after`; anything
 //    not flagged was inherited from the style chain and is zeroed for
-//    measurement.
+//    both measurement and painting.
 //
-// 3. **Zero trailing empty paragraph after a table** (#381) — OOXML
+// 2. **Zero trailing empty paragraph after a table** (#381) — OOXML
 //    requires a trailing block-level element after the last `<w:tbl>`
 //    in any block container, including `<w:hdr>` / `<w:ftr>`. Word
 //    renders that empty paragraph as a zero-height anchor (just the
@@ -68,10 +63,6 @@ export type HeaderFooterMetrics = {
 //    `spacingExplicit` are NOT suppressed — they exist for their
 //    visual side effect, not just as a structural anchor.
 
-function isAnchoredImageRun(run: Run): boolean {
-  return run.kind === 'image' && !!run.position;
-}
-
 function hasAuthoredVisualContent(block: FlowBlock): boolean {
   if (block.kind !== 'paragraph') return false;
   const attrs = block.attrs;
@@ -82,6 +73,10 @@ function hasAuthoredVisualContent(block: FlowBlock): boolean {
 }
 
 export function normalizeHeaderFooterMeasureBlocks(blocks: FlowBlock[]): FlowBlock[] {
+  return normalizeFlowBlockArray(blocks);
+}
+
+function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
   const trailingEmptyAfterTable = new Set<number>();
   for (let i = 1; i < blocks.length; i++) {
     const prev = blocks[i - 1];
@@ -94,6 +89,9 @@ export function normalizeHeaderFooterMeasureBlocks(blocks: FlowBlock[]): FlowBlo
   }
 
   return blocks.map((block, index) => {
+    if (block.kind === 'table') {
+      return normalizeTableBlock(block);
+    }
     if (block.kind !== 'paragraph') return block;
 
     const isTrailingEmpty = trailingEmptyAfterTable.has(index);
@@ -105,17 +103,7 @@ export function normalizeHeaderFooterMeasureBlocks(blocks: FlowBlock[]): FlowBlo
     const afterIsInherited = hasResolvedAfter && !explicit?.after;
     const stripsSpacing = beforeIsInherited || afterIsInherited;
 
-    const stripsImages = block.runs.some(isAnchoredImageRun);
-
-    if (!stripsSpacing && !stripsImages && !isTrailingEmpty) return block;
-
-    let inlineRuns: Run[] = block.runs;
-    if (stripsImages) {
-      inlineRuns = block.runs.filter((r) => !isAnchoredImageRun(r));
-      if (inlineRuns.length === 0) {
-        inlineRuns = [{ kind: 'text' as const, text: '' }];
-      }
-    }
+    if (!stripsSpacing && !isTrailingEmpty) return block;
 
     let attrs = block.attrs;
     if (stripsSpacing && attrs?.spacing) {
@@ -133,8 +121,27 @@ export function normalizeHeaderFooterMeasureBlocks(blocks: FlowBlock[]): FlowBlo
       attrs = { ...(attrs ?? {}), suppressEmptyParagraphHeight: true };
     }
 
-    return { ...block, runs: inlineRuns, attrs };
+    return { ...block, attrs };
   });
+}
+
+function normalizeTableBlock(block: TableBlock): TableBlock {
+  let changed = false;
+  const rows = block.rows.map((row) => {
+    let rowChanged = false;
+    const cells = row.cells.map((cell) => {
+      const normalizedBlocks = normalizeFlowBlockArray(cell.blocks);
+      const cellChanged = normalizedBlocks.some((normalizedBlock, idx) => normalizedBlock !== cell.blocks[idx]);
+      if (!cellChanged) return cell;
+      rowChanged = true;
+      return { ...cell, blocks: normalizedBlocks };
+    });
+    if (!rowChanged) return row;
+    changed = true;
+    return { ...row, cells };
+  });
+
+  return changed ? { ...block, rows } : block;
 }
 
 // ============================================================================
@@ -289,15 +296,10 @@ export function convertHeaderFooterToContent(
     if (m.kind === 'textBox') return h + m.height;
     return h;
   }, 0);
-  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(
-    blocks,
-    measures,
-    totalHeight,
-    metrics
-  );
+  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(blocks, measures, totalHeight, metrics);
 
   return {
-    blocks,
+    blocks: blocksForMeasure,
     measures,
     height: totalHeight,
     visualTop,

--- a/packages/core/src/layout-bridge/measuring/__tests__/suppress-empty-paragraph-height.test.ts
+++ b/packages/core/src/layout-bridge/measuring/__tests__/suppress-empty-paragraph-height.test.ts
@@ -1,14 +1,13 @@
 /**
- * Regression test for #381 — empty paragraphs flagged with
- * `suppressEmptyParagraphHeight` measure as zero-height anchors.
+ * Regression tests for empty header/footer paragraphs.
  *
- * Used by the HF measurement pipeline to handle the canonical OOXML
- * "trailing empty paragraph after a table" pattern: the paragraph mark
- * exists in the document model but Word renders it as a zero-height
- * anchor, not a full line-height of phantom space.
+ * - #381: structural trailing empty paragraphs after a table can be suppressed
+ *   to zero height when the caller marks them as anchors only.
+ * - Empty paragraphs that still carry explicit spacing must keep that authored
+ *   spacing, even when they arrive as a single empty text run.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { measureParagraph } from '../measureParagraph';
 import type { ParagraphBlock } from '../../../layout-engine/types';
 
@@ -21,7 +20,7 @@ function emptyPara(attrs: ParagraphBlock['attrs'] = {}): ParagraphBlock {
   };
 }
 
-describe('measureParagraph — suppressEmptyParagraphHeight (#381)', () => {
+describe('measureParagraph - empty paragraph handling', () => {
   test('empty paragraph without flag uses default empty-line height', () => {
     const measure = measureParagraph(emptyPara(), 600);
     expect(measure.totalHeight).toBeGreaterThan(0);
@@ -38,8 +37,23 @@ describe('measureParagraph — suppressEmptyParagraphHeight (#381)', () => {
     expect(measure.lines[0].descent).toBe(0);
   });
 
-  // Non-empty paragraphs ignore the flag by construction — the
-  // suppress branch is gated on `runs.length === 0`. Not worth a
-  // separate test (would need a Canvas-backed environment for real
-  // text measurement).
+  for (const text of ['', ' ', '\u00a0']) {
+    test(`single visually empty text run (${JSON.stringify(text)}) still preserves explicit spacing before/after`, () => {
+      const measure = measureParagraph(
+        {
+          kind: 'paragraph',
+          id: 'spaced-empty-run',
+          runs: [{ kind: 'text', text }],
+          attrs: {
+            spacing: { before: 8, after: 4 },
+          },
+        } as ParagraphBlock,
+        600
+      );
+
+      expect(measure.lines.length).toBe(1);
+      expect(measure.lines[0].lineHeight).toBeGreaterThan(0);
+      expect(measure.totalHeight).toBeCloseTo(measure.lines[0].lineHeight + 12, 4);
+    });
+  }
 });

--- a/packages/core/src/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/core/src/layout-bridge/measuring/measureParagraph.ts
@@ -276,7 +276,7 @@ function isFieldRun(run: Run): run is FieldRun {
  * Check if text run is empty (only whitespace or no text)
  */
 function isEmptyTextRun(run: TextRun): boolean {
-  return !run.text || run.text.length === 0;
+  return !run.text || run.text.replace(/\u00a0/g, ' ').trim().length === 0;
 }
 
 /**
@@ -455,10 +455,14 @@ export function measureParagraph(
       ...emptyMetrics,
     });
 
+    let emptyTotal = emptyMetrics.lineHeight;
+    if (spacing?.before) emptyTotal += spacing.before;
+    if (spacing?.after) emptyTotal += spacing.after;
+
     return {
       kind: 'paragraph',
       lines,
-      totalHeight: emptyMetrics.lineHeight,
+      totalHeight: emptyTotal,
     };
   }
 

--- a/packages/core/src/layout-painter/__tests__/header-footer-spacing.test.ts
+++ b/packages/core/src/layout-painter/__tests__/header-footer-spacing.test.ts
@@ -1,0 +1,97 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { PAGE_CLASS_NAMES, renderPage, type HeaderFooterContent } from '../renderPage';
+import type { Page, ParagraphBlock, ParagraphMeasure } from '../../layout-engine/types';
+
+beforeAll(() => GlobalRegistrator.register());
+afterAll(() => GlobalRegistrator.unregister());
+
+function makePage(): Page {
+  return {
+    number: 1,
+    fragments: [],
+    margins: {
+      top: 96,
+      right: 96,
+      bottom: 96,
+      left: 96,
+      header: 48,
+      footer: 48,
+    },
+    size: { w: 816, h: 1056 },
+  };
+}
+
+function makeSeparatorContent(): HeaderFooterContent {
+  const block: ParagraphBlock = {
+    kind: 'paragraph',
+    id: 'separator',
+    runs: [],
+    attrs: {
+      spacing: { before: 8 },
+      spacingExplicit: { before: true },
+      borders: {
+        bottom: {
+          style: 'solid',
+          width: 1,
+          color: '#7A1F2B',
+          space: 1.3333333333333333,
+        },
+      },
+      defaultFontSize: 11,
+      defaultFontFamily: 'Calibri',
+    },
+  };
+
+  const measure: ParagraphMeasure = {
+    kind: 'paragraph',
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 0,
+        width: 0,
+        ascent: 11,
+        descent: 4,
+        lineHeight: 17.9,
+      },
+    ],
+    totalHeight: 25.9,
+  };
+
+  return {
+    blocks: [block],
+    measures: [measure],
+    height: 25.9,
+    visualTop: 0,
+    visualBottom: 25.9,
+  };
+}
+
+describe('renderPage header/footer paragraph spacing', () => {
+  test('header paragraph honors explicit spacing.before in fragment positioning', () => {
+    const page = makePage();
+    const headerContent = makeSeparatorContent();
+
+    const el = renderPage(
+      page,
+      {
+        pageNumber: 1,
+        totalPages: 1,
+        section: 'body',
+      },
+      {
+        document,
+        headerContent,
+      }
+    );
+
+    const headerEl = el.querySelector(`.${PAGE_CLASS_NAMES.header}`);
+    expect(headerEl).toBeTruthy();
+
+    const paragraphEl = headerEl?.querySelector('.layout-paragraph') as HTMLElement | null;
+    expect(paragraphEl).toBeTruthy();
+    expect(paragraphEl?.style.top).toBe('8px');
+  });
+});

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -930,6 +930,7 @@ function renderHeaderFooterContent(
     if (block.kind === 'paragraph' && measure.kind === 'paragraph') {
       const paragraphBlock = block as ParagraphBlock;
       const paragraphMeasure = measure as ParagraphMeasure;
+      const paragraphSpacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
 
       // Track the Y position where this paragraph starts
       const paragraphStartY = cursorY;
@@ -984,7 +985,7 @@ function renderHeaderFooterContent(
         kind: 'paragraph',
         blockId: paragraphBlock.id,
         x: 0,
-        y: cursorY,
+        y: cursorY + paragraphSpacingBefore,
         width: contentWidth,
         height: paragraphMeasure.totalHeight,
         fromLine: 0,
@@ -1005,7 +1006,7 @@ function renderHeaderFooterContent(
         { document: doc }
       );
 
-      fragEl.style.top = `${cursorY}px`;
+      fragEl.style.top = `${cursorY + paragraphSpacingBefore}px`;
       fragEl.style.left = '0';
       fragEl.style.width = `${contentWidth}px`;
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -5,10 +5,16 @@
  * is correctly resolved to RGB values on ProseMirror tableCell node attrs.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { afterAll, beforeAll, describe, test, expect } from 'bun:test';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { DOMSerializer } from 'prosemirror-model';
 import { toProseDoc } from './toProseDoc';
 import { fromProseDoc } from './fromProseDoc';
+import { schema } from '../schema';
 import type { Document, Table, TableRow, TableCell, Theme } from '../../types/document';
+
+beforeAll(() => GlobalRegistrator.register());
+afterAll(() => GlobalRegistrator.unregister());
 
 const OFFICE_THEME: Theme = {
   colorScheme: {
@@ -134,6 +140,26 @@ describe('toProseDoc — table cell theme color resolution', () => {
     expect(cells[0].backgroundColor).toBe('8FAADC');
     // tint=33 (0.2) → near-white
     expect(cells[1].backgroundColor).toBe('DAE3F3');
+  });
+});
+
+describe('ProseMirror table cell DOM serialization', () => {
+  test('OOXML auto border colors serialize to valid CSS colors', () => {
+    const borders = {
+      top: { style: 'single', size: 8, color: { rgb: 'auto' } },
+      bottom: { style: 'single', size: 8, color: { rgb: 'auto' } },
+      left: { style: 'single', size: 8, color: { rgb: 'auto' } },
+      right: { style: 'single', size: 8, color: { rgb: 'auto' } },
+    };
+    const cell = schema.nodes.tableCell.create({ borders }, schema.nodes.paragraph.create());
+
+    const dom = DOMSerializer.fromSchema(schema).serializeNode(cell) as HTMLElement;
+    const style = dom.getAttribute('style') ?? '';
+
+    expect(style).toContain('border-width: 1px');
+    expect(style).toContain('border-style: solid');
+    expect(style).toContain('border-color: #000000');
+    expect(style).not.toContain('#auto');
   });
 });
 

--- a/packages/core/src/prosemirror/editor.css
+++ b/packages/core/src/prosemirror/editor.css
@@ -639,10 +639,22 @@
 }
 
 /* Header/footer editor ProseMirror styles */
+.hf-editor-pm.prosemirror-editor {
+  width: 100%;
+  max-width: 100%;
+}
 .hf-editor-pm .ProseMirror {
   outline: none;
   min-height: 40px;
   padding: 4px;
+}
+.hf-editor-pm.prosemirror-editor .ProseMirror {
+  width: 100%;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 4px;
+  background: transparent;
+  box-shadow: none;
 }
 .hf-editor-pm .ProseMirror:focus {
   outline: none;

--- a/packages/core/src/prosemirror/editor.css
+++ b/packages/core/src/prosemirror/editor.css
@@ -427,10 +427,10 @@
   /* Text wrapping handled via inline styles based on noWrap attribute */
 }
 
-/* Table header cells - styling comes from inline styles, not CSS defaults */
+/* Table header cells are structural; DOCX text formatting comes from marks/styles. */
 .prosemirror-editor .ProseMirror th.docx-table-header {
-  font-weight: bold;
-  text-align: left;
+  font-weight: inherit;
+  text-align: inherit;
 }
 
 /* Cell content - paragraphs inside cells */
@@ -646,13 +646,13 @@
 .hf-editor-pm .ProseMirror {
   outline: none;
   min-height: 40px;
-  padding: 4px;
+  padding: 0;
 }
 .hf-editor-pm.prosemirror-editor .ProseMirror {
   width: 100%;
   max-width: 100%;
   min-height: 40px;
-  padding: 4px;
+  padding: 0;
   background: transparent;
   box-shadow: none;
 }
@@ -661,17 +661,70 @@
 }
 .hf-editor-pm .ProseMirror p {
   display: block;
-  /* !important overrides inline margin-bottom from style-resolved spaceAfter.
-     The layout painter doesn't apply style-resolved spacing to headers/footers,
-     so the editor must match by stripping paragraph margins. */
+  /*
+     Keep margins flattened for the inline header/footer editor, but preserve
+     authored DOCX spacing through serializer-emitted CSS variables so
+     standalone paragraphs (like separator lines after header tables) stay in
+     rhythm with the static renderer.
+  */
   margin: 0 !important;
-  padding: 0;
+  padding-top: var(--docx-space-before, 0);
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  padding-right: 0;
   min-height: 1em;
   white-space: pre-wrap;
   word-wrap: break-word;
   /* Override inline line-height from style-resolved lineSpacing to match
      the layout painter's rendering of header/footer content */
   line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror td p,
+.hf-editor-pm .ProseMirror th p {
+  margin: 0 !important;
+  /*
+     Native table-cell layout in the inline header/footer editor flattens paragraph
+     margins, so preserve DOCX spacing using padding variables emitted by the
+     paragraph DOM serializer instead of margin-top/margin-bottom.
+  */
+  padding-top: var(--docx-space-before, 0);
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  padding-right: 0;
+  min-height: auto;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror .tableWrapper {
+  overflow: visible;
+}
+
+.hf-editor-pm .ProseMirror table {
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  table-layout: fixed !important;
+  margin: 0;
+}
+
+.hf-editor-pm .ProseMirror td.docx-table-cell,
+.hf-editor-pm .ProseMirror th.docx-table-header {
+  box-sizing: border-box !important;
+}
+
+/* Remove the parent paragraph font strut; run spans keep their DOCX font metrics. */
+.hf-editor-pm .ProseMirror td p:has(img),
+.hf-editor-pm .ProseMirror th p:has(img),
+.hf-editor-pm .ProseMirror td p:has(span),
+.hf-editor-pm .ProseMirror th p:has(span) {
+  font-size: 0 !important;
+  line-height: 0 !important;
+}
+
+.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
+.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
+  position: relative;
+  top: 0.4em;
 }
 
 /* ============================================================================

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -50,6 +50,12 @@ function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
   };
 
   const style = paragraphToStyle(formatting);
+  if (style.marginTop) {
+    style['--docx-space-before'] = style.marginTop;
+  }
+  if (style.marginBottom) {
+    style['--docx-space-after'] = style.marginBottom;
+  }
   return Object.entries(style)
     .map(([key, value]) => {
       const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -26,6 +26,7 @@ import { createNodeExtension, createExtension } from '../create';
 import type { ExtensionContext, ExtensionRuntime, AnyExtension } from '../types';
 import type { TableAttrs, TableRowAttrs, TableCellAttrs } from '../../schema/nodes';
 import type { ColorValue, BorderSpec } from '../../../types/colors';
+import { resolveColor } from '../../../utils/colorResolver';
 
 // ============================================================================
 // CSS PASTE HELPERS — Extract formatting from inline styles (Google Docs, etc.)
@@ -301,14 +302,14 @@ function buildCellBorderStyles(attrs: TableCellAttrs): string[] {
   const borderToCss = (border?: {
     style?: string;
     size?: number;
-    color?: { rgb?: string };
+    color?: ColorValue;
   }): string => {
     if (!border || !border.style || border.style === 'none' || border.style === 'nil') {
       return 'none';
     }
     const widthPx = border.size ? Math.max(1, Math.round((border.size / 8) * 1.333)) : 1;
     const cssStyle = BORDER_STYLE_CSS[border.style] || 'solid';
-    const color = border.color?.rgb ? `#${border.color.rgb}` : '#000000';
+    const color = resolveColor(border.color, undefined);
     return `${widthPx}px ${cssStyle} ${color}`;
   };
 

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -299,11 +299,7 @@ function buildCellBorderStyles(attrs: TableCellAttrs): string[] {
 
   if (!borders) return styles;
 
-  const borderToCss = (border?: {
-    style?: string;
-    size?: number;
-    color?: ColorValue;
-  }): string => {
+  const borderToCss = (border?: { style?: string; size?: number; color?: ColorValue }): string => {
     if (!border || !border.style || border.style === 'none' || border.style === 'nil') {
       return 'none';
     }

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -4378,7 +4378,7 @@ body { background: white; }
     }
 
     const pkg = history.state.package;
-    const sectionProps = initialSectionProperties;
+    const sectionProps = finalSectionProperties ?? initialSectionProperties;
     const headers = pkg.headers;
     const footers = pkg.footers;
 
@@ -4421,7 +4421,7 @@ body { background: white; }
       firstPageHeaderContent: firstHeader,
       firstPageFooterContent: firstFooter,
     };
-  }, [history.state, initialSectionProperties]);
+  }, [history.state, initialSectionProperties, finalSectionProperties]);
 
   // Handle header/footer double-click — open editing overlay
   // If no header/footer exists, create an empty one so the user can add content

--- a/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -358,7 +358,7 @@ export const InlineHeaderFooterEditor = forwardRef<
       {/* ProseMirror editor area */}
       <div
         ref={editorContainerRef}
-        className="hf-editor-pm"
+        className="hf-editor-pm prosemirror-editor"
         style={{
           minHeight: 40,
           outline: 'none',

--- a/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import type { FlowBlock, Measure, ParagraphBlock, ParagraphMeasure } from '@eigenpal/docx-core/layout-engine';
+import { measureTableCellBlockVisualHeight } from './PagedEditor';
+
+function paragraphBlock(runs: ParagraphBlock['runs'], attrs?: ParagraphBlock['attrs']): ParagraphBlock {
+  return {
+    kind: 'paragraph',
+    id: 'p1',
+    runs,
+    attrs,
+  };
+}
+
+function paragraphMeasure(totalHeight: number, lineHeight: number): ParagraphMeasure {
+  return {
+    kind: 'paragraph',
+    lines: [
+      {
+        fromRun: 0,
+        toRun: 0,
+        fromChar: 0,
+        toChar: 0,
+        width: lineHeight,
+        ascent: lineHeight,
+        descent: 0,
+        lineHeight,
+      },
+    ],
+    totalHeight,
+  };
+}
+
+describe('measureTableCellBlockVisualHeight', () => {
+  test('keeps normal paragraph total height for text content', () => {
+    const block = paragraphBlock([{ kind: 'text', text: 'hello' }]);
+    const measure = paragraphMeasure(17.9, 17.9);
+
+    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(17.9);
+  });
+
+  test('uses image height for single-line image-only paragraphs', () => {
+    const block = paragraphBlock(
+      [{ kind: 'image', src: 'logo.png', width: 186, height: 29 }],
+      { spacing: { before: 0, after: 0 } }
+    );
+    const measure = paragraphMeasure(34.859375, 34.859375);
+
+    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(29);
+  });
+
+  test('preserves explicit spacing around image-only paragraphs', () => {
+    const block = paragraphBlock(
+      [{ kind: 'image', src: 'logo.png', width: 186, height: 29 }],
+      { spacing: { before: 8, after: 4 } }
+    );
+    const measure = paragraphMeasure(40, 40);
+
+    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(41);
+  });
+
+  test('falls back to totalHeight for non-paragraph measures', () => {
+    const block: FlowBlock = {
+      kind: 'image',
+      id: 'img1',
+      src: 'logo.png',
+      width: 186,
+      height: 29,
+    };
+    const measure: Measure = {
+      kind: 'image',
+      width: 186,
+      height: 29,
+    };
+
+    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(29);
+  });
+});

--- a/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from 'bun:test';
-import type { FlowBlock, Measure, ParagraphBlock, ParagraphMeasure } from '@eigenpal/docx-core/layout-engine';
+import type {
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+} from '@eigenpal/docx-core/layout-engine';
 import { measureTableCellBlockVisualHeight } from './PagedEditor';
 
-function paragraphBlock(runs: ParagraphBlock['runs'], attrs?: ParagraphBlock['attrs']): ParagraphBlock {
+function paragraphBlock(
+  runs: ParagraphBlock['runs'],
+  attrs?: ParagraphBlock['attrs']
+): ParagraphBlock {
   return {
     kind: 'paragraph',
     id: 'p1',
@@ -39,20 +47,18 @@ describe('measureTableCellBlockVisualHeight', () => {
   });
 
   test('uses image height for single-line image-only paragraphs', () => {
-    const block = paragraphBlock(
-      [{ kind: 'image', src: 'logo.png', width: 186, height: 29 }],
-      { spacing: { before: 0, after: 0 } }
-    );
+    const block = paragraphBlock([{ kind: 'image', src: 'logo.png', width: 186, height: 29 }], {
+      spacing: { before: 0, after: 0 },
+    });
     const measure = paragraphMeasure(34.859375, 34.859375);
 
     expect(measureTableCellBlockVisualHeight(block, measure)).toBe(29);
   });
 
   test('preserves explicit spacing around image-only paragraphs', () => {
-    const block = paragraphBlock(
-      [{ kind: 'image', src: 'logo.png', width: 186, height: 29 }],
-      { spacing: { before: 8, after: 4 } }
-    );
+    const block = paragraphBlock([{ kind: 'image', src: 'logo.png', width: 186, height: 29 }], {
+      spacing: { before: 8, after: 4 },
+    });
     const measure = paragraphMeasure(40, 40);
 
     expect(measureTableCellBlockVisualHeight(block, measure)).toBe(41);

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -49,6 +49,8 @@ import type {
   FlowBlock,
   Measure,
   ParagraphBlock,
+  ParagraphMeasure,
+  TableCell,
   TableBlock,
   TableMeasure,
   ImageBlock,
@@ -629,7 +631,41 @@ function computePerBlockWidths(
 // duplicates were drifting from the canonical implementations; sharing
 // keeps them in lockstep across React + Vue adapters.
 
-function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableMeasure {
+export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure: Measure): number {
+  if (block.kind !== 'paragraph' || blockMeasure.kind !== 'paragraph') {
+    if ('totalHeight' in blockMeasure) return blockMeasure.totalHeight;
+    if ('height' in blockMeasure) return blockMeasure.height;
+    return 0;
+  }
+
+  const paragraphBlock = block as ParagraphBlock;
+  const paragraphMeasure = blockMeasure as ParagraphMeasure;
+  const nonEmptyRuns = paragraphBlock.runs.filter((run) => run.kind !== 'text' || run.text.length > 0);
+  const imageOnlySingleLine =
+    paragraphMeasure.lines.length === 1 &&
+    nonEmptyRuns.length > 0 &&
+    nonEmptyRuns.every((run) => run.kind === 'image');
+
+  if (!imageOnlySingleLine) {
+    return paragraphMeasure.totalHeight;
+  }
+
+  const maxImageHeight = nonEmptyRuns.reduce((maxHeight, run) => {
+    return run.kind === 'image' ? Math.max(maxHeight, run.height) : maxHeight;
+  }, 0);
+  const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+  const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
+
+  return spacingBefore + maxImageHeight + spacingAfter;
+}
+
+function getTableCellVerticalBorderHeight(cell: TableCell | undefined): number {
+  const top = cell?.borders?.top?.width ?? 0;
+  const bottom = cell?.borders?.bottom?.width ?? 0;
+  return top + bottom;
+}
+
+export function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableMeasure {
   const DEFAULT_CELL_PADDING_X = 7; // Word default: 108 twips ≈ 7px
   const DEFAULT_CELL_PADDING_Y = 0; // OOXML/TableNormal default: top=0, bottom=0
 
@@ -725,6 +761,7 @@ function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableM
     const row = rows[rowIdx];
     const sourceRowCells = tableBlock.rows[rowIdx]?.cells;
     let maxHeight = 0;
+    let maxVerticalBorderHeight = 0;
     for (let cellIdx = 0; cellIdx < row.cells.length; cellIdx++) {
       const cell = row.cells[cellIdx];
       const sourceCell = sourceRowCells?.[cellIdx];
@@ -733,10 +770,11 @@ function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableM
       // collapse rules don't apply across the cell-content boundary, so this
       // matches Word's per-cell layout.
       let contentHeight = 0;
-      for (const blockMeasure of cell.blocks) {
-        if ('totalHeight' in blockMeasure) {
-          contentHeight += blockMeasure.totalHeight;
-        }
+      for (let blockIdx = 0; blockIdx < cell.blocks.length; blockIdx++) {
+        const sourceBlock = sourceCell?.blocks[blockIdx];
+        const blockMeasure = cell.blocks[blockIdx];
+        if (!sourceBlock || !blockMeasure) continue;
+        contentHeight += measureTableCellBlockVisualHeight(sourceBlock, blockMeasure);
       }
 
       cell.height = contentHeight;
@@ -744,6 +782,10 @@ function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableM
       const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
       cell.height += padTop + padBottom;
       maxHeight = Math.max(maxHeight, cell.height);
+      maxVerticalBorderHeight = Math.max(
+        maxVerticalBorderHeight,
+        getTableCellVerticalBorderHeight(sourceCell)
+      );
     }
 
     // Apply heightRule from the source row
@@ -756,10 +798,10 @@ function measureTableBlock(tableBlock: TableBlock, contentWidth: number): TableM
     } else if (explicitHeight) {
       // Both 'atLeast' and 'auto' (OOXML default) treat the value as minimum height.
       // ECMA-376 §17.4.81: when hRule is absent or "auto", val is the minimum row height.
-      row.height = Math.max(maxHeight, explicitHeight);
+      row.height = Math.max(maxHeight + maxVerticalBorderHeight, explicitHeight);
     } else {
       // No explicit height — use content height directly.
-      row.height = maxHeight;
+      row.height = maxHeight + maxVerticalBorderHeight;
     }
   }
 

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -640,7 +640,9 @@ export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure
 
   const paragraphBlock = block as ParagraphBlock;
   const paragraphMeasure = blockMeasure as ParagraphMeasure;
-  const nonEmptyRuns = paragraphBlock.runs.filter((run) => run.kind !== 'text' || run.text.length > 0);
+  const nonEmptyRuns = paragraphBlock.runs.filter(
+    (run) => run.kind !== 'text' || run.text.length > 0
+  );
   const imageOnlySingleLine =
     paragraphMeasure.lines.length === 1 &&
     nonEmptyRuns.length > 0 &&

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -500,19 +500,63 @@
 .hf-editor-pm .ProseMirror {
   outline: none;
   min-height: 40px;
-  padding: 4px;
+  padding: 0;
 }
 .hf-editor-pm .ProseMirror:focus {
   outline: none;
 }
 .hf-editor-pm .ProseMirror p {
   display: block;
-  margin: 0;
-  padding: 0;
+  margin: 0 !important;
+  padding-top: var(--docx-space-before, 0);
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  padding-right: 0;
   min-height: 1em;
   white-space: pre-wrap;
   word-wrap: break-word;
-  line-height: normal;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror td p,
+.hf-editor-pm .ProseMirror th p {
+  margin: 0 !important;
+  padding-top: var(--docx-space-before, 0);
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  padding-right: 0;
+  min-height: auto;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror .tableWrapper {
+  overflow: visible;
+}
+
+.hf-editor-pm .ProseMirror table {
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  table-layout: fixed !important;
+  margin: 0;
+}
+
+.hf-editor-pm .ProseMirror td.docx-table-cell,
+.hf-editor-pm .ProseMirror th.docx-table-header {
+  box-sizing: border-box !important;
+}
+
+.hf-editor-pm .ProseMirror td p:has(img),
+.hf-editor-pm .ProseMirror th p:has(img),
+.hf-editor-pm .ProseMirror td p:has(span),
+.hf-editor-pm .ProseMirror th p:has(span) {
+  font-size: 0 !important;
+  line-height: 0 !important;
+}
+
+.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
+.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
+  position: relative;
+  top: 0.4em;
 }
 
 /* Dim body content when editing header/footer */


### PR DESCRIPTION
## Summary

This PR fixes a group of header/footer fidelity and lifecycle issues for DOCX documents that use table-based headers or footers.

The main goal is to make three views agree much more closely:

- the normal paged render
- the inline header/footer editor
- the Word/PDF reference output

The patch focuses on layout fidelity, editor parity, and header/footer editing correctness without introducing template-specific behavior.

## Problems

Before this patch, header/footer content with tables could diverge across render paths:

- inherited paragraph spacing could affect header/footer layout even when Word did not visually apply it
- structural empty paragraphs after header/footer tables could contribute height incorrectly
- image-only table-cell content could produce clipped or inflated row height
- the inline header/footer editor could drift from the static paged render
- OOXML automatic border colors could serialize to invalid CSS and make header table borders disappear in the editor
- removing a header could leave no way to recreate/edit it from the blank header area

## Root Cause

Header/footer rendering and editing were not using a fully aligned model for:

- paragraph spacing normalization
- structural empty paragraph handling
- table-cell visual height measurement
- distributed editor CSS parity
- table-cell border color serialization
- active header/footer content resolution after create/remove/save flows

In practice, this meant measurement, paint, editor DOM/CSS, and current section-reference lookup could disagree even when they were looking at the same imported DOCX content.

## What Changed

### Header/footer layout normalization

- normalized header/footer flow blocks before measurement/render where Word-specific inherited spacing should not apply
- preserved original blocks only where visual bounds still need floating-image awareness
- suppressed structural empty paragraphs immediately after header/footer tables when they are only acting as anchors

### Header/footer table measurement/render fidelity

- adjusted paragraph measurement for visually empty runs so explicit spacing still survives correctly
- improved shared table-cell visual height handling for image-only paragraphs
- aligned header/footer paint positioning with normalized paragraph spacing

### Inline editor parity

- aligned the inline header/footer editor shell with the shared ProseMirror surface
- exposed paragraph spacing to CSS via `--docx-space-before` / `--docx-space-after`
- aligned header/footer editor CSS in both core and distributed React styles
- removed header/footer editor padding drift and tightened table layout parity
- preserved border/table geometry and baseline alignment more consistently

### Header/footer lifecycle fix

- resolved active header/footer content from `finalSectionProperties ?? initialSectionProperties`
- kept header/footer editor state aligned with create/remove/save flows that already update the current package section references
- added focused e2e regression coverage for remove-header -> double-click blank header area -> recreate inline editor

### Border serialization fix

- fixed ProseMirror table-cell border serialization so OOXML automatic colors do not generate invalid CSS like `#auto`
- reused the shared color resolver instead of direct raw RGB serialization

## Scope

This PR is intentionally limited to header/footer parity and lifecycle behavior.

It includes small shared fixes only where they are the smallest correct solution for header/footer behavior:

- table-cell visual height for image-only paragraphs
- table-cell border color serialization

It does **not** try to solve the broader global table strategy covered by later work.

## Validation

Commands run:

```bash
bun test packages/core/src/layout-bridge/__tests__/normalizeHeaderFooterMeasureBlocks.test.ts packages/core/src/layout-bridge/measuring/__tests__/suppress-empty-paragraph-height.test.ts packages/core/src/layout-painter/__tests__/header-footer-spacing.test.ts packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts
bun x tsc --noEmit -p packages/core/tsconfig.json
bun x tsc --noEmit -p packages/react/tsconfig.json
bun x prettier --check e2e/tests/hf-toolbar-and-zindex.spec.ts packages/react/src/components/DocxEditor.tsx packages/react/src/paged-editor/PagedEditor.tableMeasure.test.ts packages/react/src/paged-editor/PagedEditor.tsx
git diff --check origin/main...HEAD
```

Result:

- 34 focused tests passing
- core typecheck passing
- react typecheck passing
- prettier check passing
- no diff whitespace errors beyond normal Windows CRLF warnings

Manual browser validation:

- remove header -> blank header area remains visible
- double-click blank header area -> inline header editor mounts again
- validated on the local A+B validation worktree against the real DOCX fixture

## Visual Evidence

I compared:

- regular EigenPal
- the patched implementation in this PR
- Word/PDF reference output

### Static render comparison

Word reference  
<img width="1241" height="184" alt="word_header" src="https://github.com/user-attachments/assets/a872e1d6-691e-4905-b7de-75906d605630" />

Regular EigenPal  
<img width="1060" height="186" alt="vanila_eigenpal" src="https://github.com/user-attachments/assets/2a9a3230-91f0-4c87-9d84-28e24577cb2b" />

Patched EigenPal  
<img width="1022" height="183" alt="newimplementation_header" src="https://github.com/user-attachments/assets/7775803e-1d99-45e4-88fb-08fa880b08ca" />

### Header editor comparison

Word reference  
<img width="1161" height="178" alt="word_edit" src="https://github.com/user-attachments/assets/9e00172d-ba68-4734-aef9-e1f383f77451" />

Regular EigenPal  
<img width="1044" height="240" alt="vanila_editor" src="https://github.com/user-attachments/assets/c538f9e5-4224-4045-837f-e8faad4466f4" />

Patched EigenPal  
<img width="1045" height="216" alt="newimplementation_editor" src="https://github.com/user-attachments/assets/352ac298-c799-45f9-89c2-f951d3b68439" />

## Fixture

Primary reference fixture:

- [DC_Template_Descricao_Cargo.docx](https://github.com/user-attachments/files/27528122/DC_Template_Descricao_Cargo.docx)

Reference PDF:

- [DC_Template_Descricao_Cargo_Border.pdf](https://github.com/user-attachments/files/27528121/DC_Template_Descricao_Cargo_Border.pdf)

## Notes

- This patch is based on a real Word/PDF comparison workflow, not only synthetic tests.
- The latest follow-up commit also fixes an upstream header lifecycle bug where removing a header made it impossible to recreate/edit it from the blank header area.
- The changes are split into reviewable commits so layout parity work and the lifecycle fix remain easy to inspect.
- If helpful, I can also share the exact fixture and additional before/after screenshots in the PR discussion.
