### PR TITLE
fix(core): preserve fixed table width during resize

### DIFF
--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -5,9 +5,12 @@
  * is correctly resolved to RGB values on ProseMirror tableCell node attrs.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { DOMParser, DOMSerializer } from 'prosemirror-model';
 import { toProseDoc } from './toProseDoc';
 import { fromProseDoc } from './fromProseDoc';
+import { schema } from '../schema';
 import type { Document, Table, TableRow, TableCell, Theme } from '../../types/document';
 
 const OFFICE_THEME: Theme = {
@@ -27,6 +30,9 @@ const OFFICE_THEME: Theme = {
   },
 };
 
+beforeAll(() => GlobalRegistrator.register());
+afterAll(() => GlobalRegistrator.unregister());
+
 function makeCell(shading?: TableCell['formatting'] extends infer F ? F : never): TableCell {
   return {
     type: 'tableCell',
@@ -43,6 +49,28 @@ function makeCell(shading?: TableCell['formatting'] extends infer F ? F : never)
 function makeTable(cells: TableCell[]): Table {
   const row: TableRow = { type: 'tableRow', cells };
   return { type: 'table', rows: [row] };
+}
+
+function makeWidthTypedTable(
+  cells: TableCell[],
+  columnWidths: number[],
+  width?: number,
+  type: 'dxa' | 'pct' = 'dxa'
+): Table {
+  const row: TableRow = { type: 'tableRow', cells };
+  return {
+    type: 'table',
+    rows: [row],
+    columnWidths,
+    formatting: width
+      ? {
+          width: {
+            value: width,
+            type,
+          },
+        }
+      : undefined,
+  };
 }
 
 function makeDocument(table: Table, theme?: Theme): Document {
@@ -134,6 +162,68 @@ describe('toProseDoc — table cell theme color resolution', () => {
     expect(cells[0].backgroundColor).toBe('8FAADC');
     // tint=33 (0.2) → near-white
     expect(cells[1].backgroundColor).toBe('DAE3F3');
+  });
+
+  test('fixed-width imported table cells materialize colwidth in px for PM resizing', () => {
+    const leftCell = makeCell({
+      width: { value: 4200, type: 'dxa' },
+    });
+    const rightCell = makeCell({
+      width: { value: 4826, type: 'dxa' },
+    });
+
+    const doc = makeDocument(makeWidthTypedTable([leftCell, rightCell], [4200, 4826], 9026));
+    const pmDoc = toProseDoc(doc);
+    const cells = collectCellAttrs(pmDoc);
+
+    expect(cells[0].width).toBe(4200);
+    expect(cells[0].widthType).toBe('dxa');
+    expect(cells[0].colwidth).toEqual([280]);
+
+    expect(cells[1].width).toBe(4826);
+    expect(cells[1].widthType).toBe('dxa');
+    expect(cells[1].colwidth).toEqual([322]);
+  });
+
+  test('fixed-width imported table cells serialize and parse data-colwidth for PM resize handles', () => {
+    const leftCell = makeCell({
+      width: { value: 4200, type: 'dxa' },
+    });
+    const rightCell = makeCell({
+      width: { value: 4826, type: 'dxa' },
+    });
+
+    const doc = makeDocument(makeWidthTypedTable([leftCell, rightCell], [4200, 4826], 9026));
+    const pmDoc = toProseDoc(doc);
+    const serializer = DOMSerializer.fromSchema(schema);
+    const fragment = serializer.serializeFragment(pmDoc.content, { document });
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+
+    const domCells = Array.from(container.querySelectorAll('td, th'));
+    expect(domCells[0]?.getAttribute('data-colwidth')).toBe('280');
+    expect(domCells[1]?.getAttribute('data-colwidth')).toBe('322');
+
+    const parsed = DOMParser.fromSchema(schema).parse(container);
+    const parsedCells = collectCellAttrs(parsed);
+    expect(parsedCells[0].colwidth).toEqual([280]);
+    expect(parsedCells[1].colwidth).toEqual([322]);
+  });
+
+  test('non-fixed imported tables do not materialize fixed colwidth metadata', () => {
+    const leftCell = makeCell({
+      width: { value: 4200, type: 'dxa' },
+    });
+    const rightCell = makeCell({
+      width: { value: 4826, type: 'dxa' },
+    });
+
+    const doc = makeDocument(makeWidthTypedTable([leftCell, rightCell], [4200, 4826], 5000, 'pct'));
+    const pmDoc = toProseDoc(doc);
+    const cells = collectCellAttrs(pmDoc);
+
+    expect(cells[0].colwidth).toBeFalsy();
+    expect(cells[1].colwidth).toBeFalsy();
   });
 });
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -49,6 +49,10 @@ import { resolveColorToHex } from '../../utils/colorResolver';
 import { mergeTextFormatting } from '../../utils/textFormattingMerge';
 import type { Theme } from '../../types/document';
 
+function twipsToPixels(twips: number): number {
+  return Math.round((twips / 1440) * 96);
+}
+
 /**
  * Options for document conversion
  */
@@ -661,6 +665,7 @@ function convertTable(
       isFirstRowStyled,
       columnWidths,
       totalWidth,
+      table.formatting?.width?.type,
       conditionalStyles,
       rowBandStyle,
       bandingEnabledV,
@@ -687,6 +692,7 @@ function convertTableRow(
   isHeaderRow: boolean,
   columnWidths?: number[],
   totalWidth?: number,
+  tableWidthType?: 'auto' | 'dxa' | 'nil' | 'pct',
   conditionalStyles?: {
     wholeTable?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
     firstRow?: { tcPr?: TableCellFormatting; rPr?: TextFormatting };
@@ -747,11 +753,15 @@ function convertTableRow(
 
     // Calculate the width for this cell from columnWidths if cell doesn't have own width
     let gridWidth: number | undefined;
+    let gridColumnWidths: number[] | undefined;
     if (columnWidths && totalWidth && totalWidth > 0) {
       // Sum widths for all columns this cell spans
       let cellWidthTwips = 0;
       for (let i = 0; i < colspan && colIndex + i < columnWidths.length; i++) {
         cellWidthTwips += columnWidths[colIndex + i];
+      }
+      if (tableWidthType === 'dxa') {
+        gridColumnWidths = columnWidths.slice(colIndex, colIndex + colspan);
       }
       // Convert to percentage of total table width
       gridWidth = Math.round((cellWidthTwips / totalWidth) * 100);
@@ -884,6 +894,8 @@ function convertTableRow(
         styleResolver,
         isHeaderRow,
         gridWidth,
+        tableWidthType,
+        gridColumnWidths,
         cellConditionalStyle,
         tableBorders,
         isFirstRow,
@@ -908,6 +920,8 @@ function convertTableCell(
   styleResolver: StyleResolver | null,
   isHeader: boolean,
   gridWidthPercent?: number,
+  tableWidthType?: 'auto' | 'dxa' | 'nil' | 'pct',
+  gridColumnWidths?: number[],
   conditionalStyle?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
   tableBorders?: TableBorders,
   isFirstRow?: boolean,
@@ -933,6 +947,15 @@ function convertTableCell(
     width = gridWidthPercent;
     widthType = 'pct';
   }
+  const colspan = formatting?.gridSpan ?? 1;
+  const gridColwidth =
+    gridColumnWidths && gridColumnWidths.length === colspan
+      ? gridColumnWidths.map(twipsToPixels)
+      : undefined;
+  const explicitColwidth =
+    tableWidthType === 'dxa' && widthType === 'dxa' && typeof width === 'number' && colspan === 1
+      ? [twipsToPixels(width)]
+      : undefined;
 
   // Cell's own shading wins; fall back to the table style's conditional row/col shading.
   const backgroundColor = resolveColorToHex(
@@ -964,8 +987,9 @@ function convertTableCell(
       : undefined;
 
   const attrs: TableCellAttrs = {
-    colspan: formatting?.gridSpan ?? 1,
+    colspan: colspan,
     rowspan: rowspan,
+    colwidth: explicitColwidth ?? gridColwidth,
     width: width,
     widthType: widthType,
     verticalAlign: formatting?.verticalAlign,

--- a/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -17,6 +17,7 @@ import { Selection, type Command } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import {
   columnResizing,
+  columnResizingPluginKey,
   tableEditing,
   mergeCells as pmMergeCells,
   splitCell as pmSplitCell,
@@ -26,6 +27,13 @@ import { createNodeExtension, createExtension } from '../create';
 import type { ExtensionContext, ExtensionRuntime, AnyExtension } from '../types';
 import type { TableAttrs, TableRowAttrs, TableCellAttrs } from '../../schema/nodes';
 import type { ColorValue, BorderSpec } from '../../../types/colors';
+import {
+  distributeTwipsFromPixelWeights,
+  getCellColumnStartIndexes,
+  getFirstRowColwidths,
+  getFixedTableTargetPx,
+  normalizeFixedResizeWidths,
+} from './tableFixedResizeUtils';
 
 // ============================================================================
 // CSS PASTE HELPERS — Extract formatting from inline styles (Google Docs, etc.)
@@ -159,9 +167,16 @@ function parseCellAttrsFromDOM(element: HTMLTableCellElement): TableCellAttrs {
   const style = element.style;
   const borders = extractCellBordersFromCSS(style);
   const margins = extractCellMarginsFromCSS(style);
+  const colwidth = element.dataset.colwidth
+    ? element.dataset.colwidth
+        .split(',')
+        .map((value) => Number.parseInt(value, 10))
+        .filter((value) => Number.isFinite(value))
+    : undefined;
   return {
     colspan: element.colSpan || 1,
     rowspan: element.rowSpan || 1,
+    colwidth: colwidth && colwidth.length > 0 ? colwidth : undefined,
     verticalAlign:
       (element.dataset.valign as TableCellAttrs['verticalAlign']) ||
       mapCssVerticalAlign(style.verticalAlign) ||
@@ -412,6 +427,9 @@ const tableCellSpec: NodeSpec = {
 
     if (attrs.colspan > 1) domAttrs.colspan = String(attrs.colspan);
     if (attrs.rowspan > 1) domAttrs.rowspan = String(attrs.rowspan);
+    if (attrs.colwidth && attrs.colwidth.length > 0) {
+      domAttrs['data-colwidth'] = attrs.colwidth.join(',');
+    }
 
     const styles: string[] = [];
     styles.push(...buildCellPaddingStyles(attrs));
@@ -471,6 +489,9 @@ const tableHeaderSpec: NodeSpec = {
 
     if (attrs.colspan > 1) domAttrs.colspan = String(attrs.colspan);
     if (attrs.rowspan > 1) domAttrs.rowspan = String(attrs.rowspan);
+    if (attrs.colwidth && attrs.colwidth.length > 0) {
+      domAttrs['data-colwidth'] = attrs.colwidth.join(',');
+    }
 
     const styles: string[] = ['font-weight: bold'];
     styles.push(...buildCellPaddingStyles(attrs));
@@ -797,6 +818,83 @@ export const TablePluginExtension = createExtension({
         return false;
       };
     }
+
+    function applyColumnWidthsToTable(tr: Transaction, tablePos: number, widthsPx: number[]) {
+      let nextTr = tr;
+      const table = tr.doc.nodeAt(tablePos);
+      if (!table || table.type.name !== 'table') return nextTr;
+      const tableWidthTwips = table.attrs.width as number | null;
+      if (typeof tableWidthTwips !== 'number') return nextTr;
+
+      const columnWidthsTwips = distributeTwipsFromPixelWeights(widthsPx, tableWidthTwips);
+      const rowColumnStarts = getCellColumnStartIndexes(table);
+
+      let rowPos = tablePos + 1;
+      let rowIndex = 0;
+      table.forEach((row) => {
+        if (row.type.name === 'tableRow') {
+          let cellPos = rowPos + 1;
+          let cellIndex = 0;
+          row.forEach((cell) => {
+            if (cell.type.name === 'tableCell' || cell.type.name === 'tableHeader') {
+              const columnIndex = rowColumnStarts[rowIndex]?.[cellIndex] ?? 0;
+              const colspan = (cell.attrs.colspan as number) || 1;
+              const colwidth = widthsPx.slice(columnIndex, columnIndex + colspan);
+              const widthTwips = columnWidthsTwips
+                .slice(columnIndex, columnIndex + colspan)
+                .reduce((sum, width) => sum + width, 0);
+              nextTr = nextTr.setNodeMarkup(cellPos, undefined, {
+                ...cell.attrs,
+                width: widthTwips,
+                widthType: 'dxa',
+                colwidth,
+              });
+              cellIndex++;
+            }
+            cellPos += cell.nodeSize;
+          });
+          rowIndex++;
+        }
+        rowPos += row.nodeSize;
+      });
+
+      return nextTr.setNodeMarkup(tablePos, undefined, {
+        ...table.attrs,
+        columnWidths: columnWidthsTwips,
+      });
+    }
+
+    const fixedResizeNormalizerKey = new PluginKey('fixedTableResizeNormalizer');
+    const fixedResizeNormalizerPlugin = new Plugin({
+      key: fixedResizeNormalizerKey,
+      appendTransaction(transactions, oldState, newState) {
+        if (!transactions.some((tr) => tr.docChanged)) return null;
+        if (transactions.some((tr) => tr.getMeta(fixedResizeNormalizerKey))) return null;
+
+        let tr = newState.tr;
+        let changed = false;
+
+        newState.doc.descendants((node, pos) => {
+          if (node.type.name !== 'table') return true;
+
+          const targetTotal = getFixedTableTargetPx(node);
+          const currentWidths = targetTotal ? getFirstRowColwidths(node) : null;
+          if (!targetTotal || !currentWidths) return true;
+
+          const previousTable = oldState.doc.nodeAt(pos);
+          const previousWidths =
+            previousTable?.type.name === 'table' ? getFirstRowColwidths(previousTable) : null;
+          const normalized = normalizeFixedResizeWidths(previousWidths, currentWidths, targetTotal);
+          if (!normalized) return true;
+
+          tr = applyColumnWidthsToTable(tr, pos, normalized);
+          changed = true;
+          return false;
+        });
+
+        return changed ? tr.setMeta(fixedResizeNormalizerKey, true) : null;
+      },
+    });
 
     function buildCellAttrsFromTemplate(
       templateCell: PMNode | null,
@@ -2334,6 +2432,9 @@ export const TablePluginExtension = createExtension({
       key: activeCellKey,
       props: {
         decorations(state) {
+          const resizeState = columnResizingPluginKey.getState(state);
+          if ((resizeState?.activeHandle ?? -1) > -1) return DecorationSet.empty;
+
           const { selection } = state;
           // Skip if already a CellSelection (prosemirror-tables handles that)
           if (selection instanceof CellSelection) return DecorationSet.empty;
@@ -2361,6 +2462,7 @@ export const TablePluginExtension = createExtension({
           lastColumnResizable: true,
         }),
         tableEditing(),
+        fixedResizeNormalizerPlugin,
         activeCellPlugin,
       ],
       keyboardShortcuts: {

--- a/packages/core/src/prosemirror/extensions/nodes/tableFixedResizeUtils.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/tableFixedResizeUtils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  distributeTwipsFromPixelWeights,
+  getCellColumnStartIndexes,
+  normalizeFixedResizeWidths,
+} from './tableFixedResizeUtils';
+import { schema } from '../../schema';
+
+describe('normalizeFixedResizeWidths', () => {
+  test('preserves the table total when one fixed-width column changes', () => {
+    const previous = [280, 322];
+    const current = [240, 322];
+
+    expect(normalizeFixedResizeWidths(previous, current, 602)).toEqual([240, 362]);
+  });
+
+  test('keeps narrow fixed-width tables positive while preserving the total', () => {
+    const previous = [12, 12, 12];
+    const current = [4, 12, 12];
+    const normalized = normalizeFixedResizeWidths(previous, current, 36);
+
+    expect(normalized).toEqual([12, 12, 12]);
+    expect(normalized?.reduce((sum, width) => sum + width, 0)).toBe(36);
+    expect(normalized?.every((width) => width > 0)).toBe(true);
+  });
+
+  test('returns null when total width already matches the target', () => {
+    expect(normalizeFixedResizeWidths([280, 322], [280, 322], 602)).toBeNull();
+  });
+
+  test('does not normalize when widths did not change in the current transaction', () => {
+    expect(normalizeFixedResizeWidths([280, 322], [280, 322], 600)).toBeNull();
+  });
+
+  test('preserves total and positive widths when multiple columns change', () => {
+    const normalized = normalizeFixedResizeWidths([12, 12, 12], [4, 20, 20], 36);
+
+    expect(normalized).toEqual([12, 12, 12]);
+    expect(normalized?.reduce((sum, width) => sum + width, 0)).toBe(36);
+    expect(normalized?.every((width) => width > 0)).toBe(true);
+  });
+});
+
+describe('distributeTwipsFromPixelWeights', () => {
+  test('keeps the twips total while mirroring pixel proportions', () => {
+    const widthsTwips = distributeTwipsFromPixelWeights([240, 362], 9030);
+    expect(widthsTwips.reduce((sum, width) => sum + width, 0)).toBe(9030);
+  });
+
+  test('keeps the twips total for narrow pixel widths', () => {
+    const widthsTwips = distributeTwipsFromPixelWeights([4, 16, 16], 540);
+    expect(widthsTwips).toEqual([60, 240, 240]);
+    expect(widthsTwips.reduce((sum, width) => sum + width, 0)).toBe(540);
+  });
+});
+
+describe('getCellColumnStartIndexes', () => {
+  test('skips logical columns occupied by rowspan cells', () => {
+    const paragraph = schema.nodes.paragraph.create();
+    const table = schema.nodes.table.create(
+      { width: 9030, widthType: 'dxa', columnWidths: [3010, 3010, 3010] },
+      [
+        schema.nodes.tableRow.create(null, [
+          schema.nodes.tableCell.create({ rowspan: 2, colspan: 1 }, paragraph),
+          schema.nodes.tableCell.create({ colspan: 1 }, paragraph),
+          schema.nodes.tableCell.create({ colspan: 1 }, paragraph),
+        ]),
+        schema.nodes.tableRow.create(null, [
+          schema.nodes.tableCell.create({ colspan: 1 }, paragraph),
+          schema.nodes.tableCell.create({ colspan: 1 }, paragraph),
+        ]),
+      ]
+    );
+
+    expect(getCellColumnStartIndexes(table)).toEqual([
+      [0, 1, 2],
+      [1, 2],
+    ]);
+  });
+});

--- a/packages/core/src/prosemirror/extensions/nodes/tableFixedResizeUtils.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/tableFixedResizeUtils.ts
@@ -1,0 +1,189 @@
+import type { Node as PMNode } from 'prosemirror-model';
+
+export function distributeEvenly(total: number, count: number): number[] {
+  const safeCount = Math.max(1, count);
+  const base = Math.floor(total / safeCount);
+  const widths = Array(safeCount).fill(base);
+  widths[widths.length - 1] += total - base * safeCount;
+  return widths;
+}
+
+export function distributeTwipsFromPixelWeights(
+  widthsPx: number[],
+  totalTwips: number
+): number[] {
+  const totalPx = widthsPx.reduce((sum, width) => sum + width, 0);
+  if (!totalPx) return distributeEvenly(totalTwips, widthsPx.length);
+
+  let assigned = 0;
+  return widthsPx.map((width, index) => {
+    if (index === widthsPx.length - 1) return totalTwips - assigned;
+    const nextWidth = Math.max(1, Math.round((width / totalPx) * totalTwips));
+    assigned += nextWidth;
+    return nextWidth;
+  });
+}
+
+export function getLogicalColumnCount(table: PMNode): number {
+  let columnCount = 0;
+  table.forEach((row) => {
+    if (row.type.name === 'tableRow') {
+      let rowColumnCount = 0;
+      row.forEach((cell) => {
+        rowColumnCount += (cell.attrs.colspan as number) || 1;
+      });
+      columnCount = Math.max(columnCount, rowColumnCount);
+    }
+  });
+  return columnCount;
+}
+
+export function getCellColumnStartIndexes(table: PMNode): number[][] {
+  const rowStarts: number[][] = [];
+  const occupiedByRowspan: number[] = [];
+
+  table.forEach((row) => {
+    if (row.type.name !== 'tableRow') return;
+
+    const starts: number[] = [];
+    let columnIndex = 0;
+    row.forEach((cell) => {
+      while ((occupiedByRowspan[columnIndex] ?? 0) > 0) columnIndex++;
+
+      starts.push(columnIndex);
+      const colspan = (cell.attrs.colspan as number) || 1;
+      const rowspan = (cell.attrs.rowspan as number) || 1;
+      if (rowspan > 1) {
+        for (let offset = 0; offset < colspan; offset++) {
+          occupiedByRowspan[columnIndex + offset] = Math.max(
+            occupiedByRowspan[columnIndex + offset] ?? 0,
+            rowspan
+          );
+        }
+      }
+      columnIndex += colspan;
+    });
+
+    rowStarts.push(starts);
+    for (let i = 0; i < occupiedByRowspan.length; i++) {
+      occupiedByRowspan[i] = Math.max(0, (occupiedByRowspan[i] ?? 0) - 1);
+    }
+  });
+
+  return rowStarts;
+}
+
+export function getFirstRowColwidths(table: PMNode): number[] | null {
+  const firstRow = table.firstChild;
+  if (!firstRow || firstRow.type.name !== 'tableRow') return null;
+
+  const widths: number[] = [];
+  firstRow.forEach((cell) => {
+    const colwidth = cell.attrs.colwidth as number[] | null;
+    if (!colwidth?.length) return;
+    widths.push(...colwidth);
+  });
+
+  return widths.length === getLogicalColumnCount(table) ? widths : null;
+}
+
+export function getFixedTableTargetPx(table: PMNode): number | null {
+  if (table.attrs.widthType === 'dxa' && typeof table.attrs.width === 'number') {
+    return Math.round(table.attrs.width / 15);
+  }
+  return null;
+}
+
+function getSafeMinimumWidth(targetTotal: number, columnCount: number, preferredMinWidth: number): number {
+  if (columnCount <= 0) return 1;
+  return Math.max(1, Math.min(preferredMinWidth, Math.floor(targetTotal / columnCount)));
+}
+
+function distributeWithMinimum(
+  weights: number[],
+  targetTotal: number,
+  preferredMinWidth: number
+): number[] {
+  if (weights.length === 0) return [];
+
+  const minWidth = getSafeMinimumWidth(targetTotal, weights.length, preferredMinWidth);
+  const positiveWeights = weights.map((weight) => Math.max(0, weight));
+  let remainingWeight = positiveWeights.reduce((sum, weight) => sum + weight, 0);
+  let remainingTotal = targetTotal;
+
+  return positiveWeights.map((weight, index) => {
+    const remainingColumns = positiveWeights.length - index;
+    const reservedForRest = minWidth * (remainingColumns - 1);
+    const maxCurrent = Math.max(minWidth, remainingTotal - reservedForRest);
+
+    if (index === positiveWeights.length - 1) return remainingTotal;
+
+    const proportional =
+      remainingWeight > 0
+        ? Math.round((weight / remainingWeight) * remainingTotal)
+        : Math.round(remainingTotal / remainingColumns);
+    const nextWidth = Math.min(maxCurrent, Math.max(minWidth, proportional));
+    remainingTotal -= nextWidth;
+    remainingWeight -= weight;
+    return nextWidth;
+  });
+}
+
+export function normalizeFixedResizeWidths(
+  previousWidths: number[] | null,
+  currentWidths: number[],
+  targetTotal: number
+): number[] | null {
+  const currentTotal = currentWidths.reduce((sum, width) => sum + width, 0);
+  if (currentTotal === targetTotal) return null;
+  if (
+    previousWidths?.length === currentWidths.length &&
+    currentWidths.every((width, index) => width === previousWidths[index])
+  ) {
+    return null;
+  }
+
+  const minWidth = 25;
+  const safeMinWidth = getSafeMinimumWidth(targetTotal, currentWidths.length, minWidth);
+  const changed =
+    previousWidths?.length === currentWidths.length
+      ? currentWidths
+          .map((width, index) => (width !== previousWidths[index] ? index : -1))
+          .filter((index) => index !== -1)
+      : [];
+
+  if (changed.length === 1) {
+    const changedIndex = changed[0];
+    const result = [...currentWidths];
+    const maxChangedWidth = Math.max(
+      safeMinWidth,
+      targetTotal - safeMinWidth * (currentWidths.length - 1)
+    );
+    const fixedWidth = Math.min(
+      Math.max(safeMinWidth, currentWidths[changedIndex]),
+      maxChangedWidth
+    );
+    result[changedIndex] = fixedWidth;
+
+    const remainingIndexes = result
+      .map((_, index) => index)
+      .filter((index) => index !== changedIndex);
+    const remainingTotal = targetTotal - fixedWidth;
+    const remainingWeights = remainingIndexes.map(
+      (index) => previousWidths?.[index] ?? currentWidths[index]
+    );
+    const normalizedRemainingWidths = distributeWithMinimum(
+      remainingWeights,
+      remainingTotal,
+      safeMinWidth
+    );
+
+    remainingIndexes.forEach((index, offset) => {
+      result[index] = normalizedRemainingWidths[offset];
+    });
+
+    return result;
+  }
+
+  return distributeWithMinimum(currentWidths, targetTotal, safeMinWidth);
+}


### PR DESCRIPTION
﻿## Summary

Preserve the total width of fixed-width (`dxa`) tables when resizing columns in the ProseMirror editor.

This PR keeps imported fixed-width Word tables stable during interactive column resize by materializing deterministic `colwidth` metadata, tracking fixed-width table intent through `toProseDoc`, and normalizing edited widths back to the original table total.

## Problem

Imported fixed-width tables could drift after column resize in the editor:

- dragging one column divider changed the resized cell width
- but the table total was no longer preserved
- the remaining columns were not rebalanced back to the original fixed table width
- exported DOCX could therefore diverge from the original fixed-width layout authored in Word

This was especially visible on imported tables whose width was defined in `dxa` and should behave as a fixed total-width grid.

## Root Cause

The editor had enough information to resize columns visually, but not enough persisted structure to normalize the table back to a fixed total width after the transaction:

- imported fixed-width cells were not consistently carrying ProseMirror `colwidth` metadata
- the resize path did not distinguish fixed-width (`dxa`) tables from percentage/auto tables
- after a resize, the transaction preserved the edited pixel widths but did not redistribute them back into a stable fixed-width table model for serialization/export

## What Changed

- materialize `colwidth` metadata for imported fixed-width table cells in `toProseDoc`
- thread table width intent (`dxa` vs non-fixed modes) through table conversion
- persist `data-colwidth` on table cell DOM parse/render so PM resize state round-trips correctly
- add focused fixed-resize utilities to:
  - read first-row column widths
  - compute the target fixed table total
  - normalize edited widths while preserving the total
  - distribute twips proportionally for table grid serialization
- add a `fixedResizeNormalizerPlugin` that post-processes resized fixed-width tables and rewrites cell/table widths back into a stable fixed-width state
- suppress active-cell decoration while a column resize handle is active, avoiding conflicting resize/editor visuals

## Scope

This PR is intentionally limited to fixed-width table resize behavior.

It does not change header/footer layout logic from [#425](https://github.com/eigenpal/docx-editor/pull/425), although both PRs touch some shared ProseMirror table conversion files.

## Validation

Ran:

```bash
bun test packages/core/src/prosemirror/extensions/nodes/tableFixedResizeUtils.test.ts packages/core/src/prosemirror/conversion/toProseDoc.test.ts
bun x tsc --noEmit -p packages/core/tsconfig.json
git diff --check origin/main...
```

Result:
- tests passing
- core typecheck passing
- no diff whitespace issues

## Notes For Maintainer

I kept this as a separate review slice from the header/footer work in [#425](https://github.com/eigenpal/docx-editor/pull/425) so the resize behavior can be reviewed on its own.

Functionally this patch applies cleanly on top of `main`; the connection to `#425` is organizational rather than runtime-coupled.
