### PR TITLE
Add document page view modes and wrapped page chrome

### DIFF
--- a/.changeset/nice-poets-guess.md
+++ b/.changeset/nice-poets-guess.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix page chrome alignment in wrapped document view

--- a/e2e/tests/comment-button.spec.ts
+++ b/e2e/tests/comment-button.spec.ts
@@ -10,6 +10,7 @@ import { test, expect } from '@playwright/test';
 import { EditorPage } from '../helpers/editor-page';
 
 const DEMO_DOCX_PATH = 'fixtures/demo/demo.docx';
+const MULTI_PAGE_DOCX_PATH = 'fixtures/issue-68-large.docx';
 
 /**
  * Find the floating comment button (position:absolute, z-index:50) and return its
@@ -37,12 +38,12 @@ async function findCommentButton(page: import('@playwright/test').Page) {
 }
 
 /** Right edge of the first visible page element, in viewport coordinates. */
-async function getPageRightEdge(page: import('@playwright/test').Page) {
-  return page.evaluate(() => {
-    const pageEl = document.querySelector('.layout-page') as HTMLElement | null;
+async function getPageRightEdge(page: import('@playwright/test').Page, pageIndex = 0) {
+  return page.evaluate((index) => {
+    const pageEl = document.querySelectorAll<HTMLElement>('.layout-page')[index] ?? null;
     if (!pageEl) return null;
     return pageEl.getBoundingClientRect().right;
-  });
+  }, pageIndex);
 }
 
 /**
@@ -60,6 +61,58 @@ async function findTextSpanY(page: import('@playwright/test').Page, text: string
     }
     return null;
   }, text);
+}
+
+async function selectPageViewMode(
+  page: import('@playwright/test').Page,
+  mode: 'onePage' | 'multiplePages' | 'pageWidth'
+) {
+  await page.getByTestId('page-view-mode-control').click();
+  await page.getByTestId(`page-view-mode-${mode}`).click();
+}
+
+async function selectZoomLevel(page: import('@playwright/test').Page, level: number) {
+  await page.getByTestId('zoom-control').click();
+  await page.getByTestId(`zoom-level-${level}`).click();
+}
+
+async function dragSelectTextOnRenderedPage(
+  page: import('@playwright/test').Page,
+  pageIndex: number
+) {
+  const target = await page.evaluate((index) => {
+    const pageEl = document.querySelectorAll<HTMLElement>('.layout-page')[index] ?? null;
+    if (!pageEl) return null;
+    const spans = Array.from(
+      pageEl.querySelectorAll<HTMLElement>('span[data-pm-start][data-pm-end]')
+    );
+    for (const span of spans) {
+      if ((span.textContent?.trim().length ?? 0) < 4) continue;
+      const rect = span.getBoundingClientRect();
+      if (rect.width < 30 || rect.height <= 0) continue;
+      return {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        height: rect.height,
+        width: rect.width,
+      };
+    }
+    return null;
+  }, pageIndex);
+
+  expect(target, `text span should exist on rendered page ${pageIndex + 1}`).not.toBeNull();
+  const y = target!.top + target!.height / 2;
+  await page.mouse.move(target!.left + 2, y);
+  await page.mouse.down();
+  await page.mouse.move(
+    Math.min(target!.right - 2, target!.left + Math.max(24, target!.width / 2)),
+    y,
+    {
+      steps: 6,
+    }
+  );
+  await page.mouse.up();
 }
 
 test.describe('Comment Button - Scroll Position (#185)', () => {
@@ -204,5 +257,48 @@ test.describe('Comment Button - Geometry changes (#268 dedup)', () => {
         `button drifted from page edge at width ${width}: ${btn!.centerX} vs ${pageRight}`
       ).toBeLessThan(20);
     }
+  });
+});
+
+test.describe('Comment Button - Multiple Pages geometry', () => {
+  test('floating button anchors to page 2 right edge in a wrapped row', async ({ page }) => {
+    await page.setViewportSize({ width: 1320, height: 1000 });
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.loadDocxFile(MULTI_PAGE_DOCX_PATH);
+    await page.waitForFunction(() => (window.__DOCX_EDITOR_E2E__?.getTotalPages() ?? 0) > 1, {
+      timeout: 10000,
+    });
+
+    await selectPageViewMode(page, 'multiplePages');
+    await selectZoomLevel(page, 50);
+    await page.waitForFunction(() => {
+      const pages = Array.from(document.querySelectorAll<HTMLElement>('.layout-page'));
+      if (pages.length < 2) return false;
+      const first = pages[0].getBoundingClientRect();
+      const second = pages[1].getBoundingClientRect();
+      return Math.abs(first.top - second.top) < 8 && second.left > first.right;
+    });
+
+    await dragSelectTextOnRenderedPage(page, 1);
+    await page.waitForFunction(() => {
+      const buttons = document.querySelectorAll('[data-testid="docx-editor"] button');
+      for (const btn of buttons) {
+        const style = getComputedStyle(btn);
+        if (style.position === 'absolute' && style.zIndex === '50') return true;
+      }
+      return false;
+    });
+
+    const btn = await findCommentButton(page);
+    const page1Right = await getPageRightEdge(page, 0);
+    const page2Right = await getPageRightEdge(page, 1);
+    expect(btn).not.toBeNull();
+    expect(page1Right).not.toBeNull();
+    expect(page2Right).not.toBeNull();
+
+    expect(Math.abs(btn!.centerX - page2Right!)).toBeLessThan(20);
+    expect(Math.abs(btn!.centerX - page1Right!)).toBeGreaterThan(40);
   });
 });

--- a/e2e/tests/view-modes.spec.ts
+++ b/e2e/tests/view-modes.spec.ts
@@ -97,6 +97,31 @@ test.describe('document page view modes', () => {
     });
   });
 
+  test('multiple-pages mode aligns the horizontal ruler to the first page in the row', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1320, height: 1000 });
+    await loadMultiPageFixture(page);
+
+    await selectPageViewMode(page, 'multiplePages');
+    await selectZoomLevel(page, 50);
+
+    await page.waitForFunction(() => {
+      const pages = Array.from(document.querySelectorAll<HTMLElement>('.layout-page'));
+      const ruler = document.querySelector<HTMLElement>('.docx-horizontal-ruler');
+      if (pages.length < 2 || !ruler) return false;
+      const first = pages[0].getBoundingClientRect();
+      const second = pages[1].getBoundingClientRect();
+      const rulerRect = ruler.getBoundingClientRect();
+      return (
+        Math.abs(first.top - second.top) < 8 &&
+        second.left > first.right &&
+        Math.abs(rulerRect.left - first.left) < 4 &&
+        Math.abs(rulerRect.width - first.width) < 4
+      );
+    });
+  });
+
   test('page-width mode fits the page to the viewport and responds to resize', async ({ page }) => {
     await page.setViewportSize({ width: 720, height: 900 });
     await loadMultiPageFixture(page);
@@ -120,5 +145,17 @@ test.describe('document page view modes', () => {
       if (!pageEl) return false;
       return pageEl.getBoundingClientRect().width > previousWidth + 80;
     }, narrowWidth);
+  });
+
+  test('leaving page-width mode restores the previous explicit zoom', async ({ page }) => {
+    await page.setViewportSize({ width: 1900, height: 1000 });
+    await loadMultiPageFixture(page);
+
+    await expect(page.getByTestId('zoom-control')).toContainText('100%');
+    await selectPageViewMode(page, 'pageWidth');
+    await expect(page.getByTestId('zoom-control')).toContainText('200%');
+
+    await selectPageViewMode(page, 'onePage');
+    await expect(page.getByTestId('zoom-control')).toContainText('100%');
   });
 });

--- a/e2e/tests/view-modes.spec.ts
+++ b/e2e/tests/view-modes.spec.ts
@@ -38,6 +38,11 @@ async function selectPageViewMode(page: Page, mode: 'onePage' | 'multiplePages' 
   await page.getByTestId(`page-view-mode-${mode}`).click();
 }
 
+async function selectZoomLevel(page: Page, level: number) {
+  await page.getByTestId('zoom-control').click();
+  await page.getByTestId(`zoom-level-${level}`).click();
+}
+
 test.describe('document page view modes', () => {
   test('defaults to one-page vertical stacking on wide viewports', async ({ page }) => {
     await page.setViewportSize({ width: 1900, height: 1000 });
@@ -72,6 +77,24 @@ test.describe('document page view modes', () => {
     await secondPageText.click();
     await page.keyboard.type('ViewModeSmoke');
     await expect(page.locator('.ProseMirror')).toContainText('ViewModeSmoke');
+  });
+
+  test('multiple-pages mode uses the visible zoomed width when wrapping pages', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1320, height: 1000 });
+    await loadMultiPageFixture(page);
+
+    await selectPageViewMode(page, 'multiplePages');
+    await selectZoomLevel(page, 50);
+
+    await page.waitForFunction(() => {
+      const pages = Array.from(document.querySelectorAll<HTMLElement>('.layout-page'));
+      if (pages.length < 2) return false;
+      const first = pages[0].getBoundingClientRect();
+      const second = pages[1].getBoundingClientRect();
+      return Math.abs(first.top - second.top) < 8 && second.left > first.right;
+    });
   });
 
   test('page-width mode fits the page to the viewport and responds to resize', async ({ page }) => {

--- a/e2e/tests/view-modes.spec.ts
+++ b/e2e/tests/view-modes.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * E2E coverage for document page view modes.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+import * as path from 'path';
+
+async function loadMultiPageFixture(page: Page): Promise<EditorPage> {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile(path.resolve(process.cwd(), 'e2e/fixtures/issue-68-large.docx'));
+  await page.waitForFunction(() => (window.__DOCX_EDITOR_E2E__?.getTotalPages() ?? 0) > 1, {
+    timeout: 10000,
+  });
+  return editor;
+}
+
+async function getPageRects(page: Page) {
+  return page.locator('.layout-page').evaluateAll((pages) =>
+    pages.map((el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+  );
+}
+
+async function selectPageViewMode(page: Page, mode: 'onePage' | 'multiplePages' | 'pageWidth') {
+  await page.getByTestId('page-view-mode-control').click();
+  await page.getByTestId(`page-view-mode-${mode}`).click();
+}
+
+test.describe('document page view modes', () => {
+  test('defaults to one-page vertical stacking on wide viewports', async ({ page }) => {
+    await page.setViewportSize({ width: 1900, height: 1000 });
+    await loadMultiPageFixture(page);
+
+    await expect(page.getByTestId('page-view-mode-control')).toBeVisible();
+    const rects = await getPageRects(page);
+    expect(rects.length).toBeGreaterThan(1);
+    expect(rects[1].top).toBeGreaterThan(rects[0].bottom);
+  });
+
+  test('multiple-pages mode wraps pages side by side and preserves click-to-type', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1900, height: 1000 });
+    await loadMultiPageFixture(page);
+
+    await selectPageViewMode(page, 'multiplePages');
+    await page.waitForFunction(() => {
+      const pages = Array.from(document.querySelectorAll<HTMLElement>('.layout-page'));
+      if (pages.length < 2) return false;
+      const first = pages[0].getBoundingClientRect();
+      const second = pages[1].getBoundingClientRect();
+      return Math.abs(first.top - second.top) < 8 && second.left > first.right;
+    });
+
+    const secondPageText = page
+      .locator('.layout-page')
+      .nth(1)
+      .locator('span[data-pm-start][data-pm-end]')
+      .first();
+    await secondPageText.click();
+    await page.keyboard.type('ViewModeSmoke');
+    await expect(page.locator('.ProseMirror')).toContainText('ViewModeSmoke');
+  });
+
+  test('page-width mode fits the page to the viewport and responds to resize', async ({ page }) => {
+    await page.setViewportSize({ width: 720, height: 900 });
+    await loadMultiPageFixture(page);
+
+    await selectPageViewMode(page, 'pageWidth');
+    await page.waitForFunction(() => {
+      const pageEl = document.querySelector('.layout-page');
+      let scroller = pageEl?.parentElement;
+      while (scroller && getComputedStyle(scroller).overflowY !== 'auto') {
+        scroller = scroller.parentElement;
+      }
+      if (!pageEl || !scroller) return false;
+      return pageEl.getBoundingClientRect().width < scroller.getBoundingClientRect().width;
+    });
+    const narrowWidth = (await getPageRects(page))[0].width;
+    expect(narrowWidth).toBeLessThan(760);
+
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.waitForFunction((previousWidth) => {
+      const pageEl = document.querySelector('.layout-page');
+      if (!pageEl) return false;
+      return pageEl.getBoundingClientRect().width > previousWidth + 80;
+    }, narrowWidth);
+  });
+});

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -228,6 +228,8 @@ export interface RenderPageOptions {
   footnoteArea?: FootnoteRenderItem[];
   /** Comment IDs that are resolved — skip highlight for these */
   resolvedCommentIds?: Set<number>;
+  /** Arrangement for the page container when rendering multiple pages. */
+  pageArrangement?: 'column' | 'wrapped';
 }
 
 export interface HeaderFooterLayoutInfo {
@@ -1760,6 +1762,7 @@ function computeOptionsHash(options: RenderPageOptions): string {
   // Header/footer distances
   if (options.headerDistance !== undefined) parts.push(`hd:${options.headerDistance}`);
   if (options.footerDistance !== undefined) parts.push(`fd:${options.footerDistance}`);
+  if (options.pageArrangement) parts.push(`pa:${options.pageArrangement}`);
 
   return parts.join('|');
 }
@@ -1767,12 +1770,22 @@ function computeOptionsHash(options: RenderPageOptions): string {
 /**
  * Apply standard container styles for the pages wrapper.
  */
-function applyContainerStyles(container: HTMLElement, pageGap: number): void {
+function applyContainerStyles(
+  container: HTMLElement,
+  pageGap: number,
+  pageArrangement: 'column' | 'wrapped' = 'column'
+): void {
+  const isWrapped = pageArrangement === 'wrapped';
   container.style.display = 'flex';
-  container.style.flexDirection = 'column';
-  container.style.alignItems = 'center';
+  container.style.flexDirection = isWrapped ? 'row' : 'column';
+  container.style.flexWrap = isWrapped ? 'wrap' : 'nowrap';
+  container.style.justifyContent = isWrapped ? 'center' : '';
+  container.style.alignItems = isWrapped ? 'flex-start' : 'center';
+  container.style.alignContent = isWrapped ? 'flex-start' : '';
   container.style.gap = `${pageGap}px`;
   container.style.padding = `${pageGap}px`;
+  container.style.width = '100%';
+  container.style.boxSizing = 'border-box';
   container.style.backgroundColor = 'var(--doc-bg, #f8f9fa)';
 }
 
@@ -1936,7 +1949,7 @@ export function renderPages(
   container.innerHTML = '';
   pc.__pageRenderState = undefined;
 
-  applyContainerStyles(container, pageGap);
+  applyContainerStyles(container, pageGap, options.pageArrangement);
 
   // Build all page shells
   const pageShells: HTMLElement[] = [];

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -230,6 +230,8 @@ export interface RenderPageOptions {
   resolvedCommentIds?: Set<number>;
   /** Arrangement for the page container when rendering multiple pages. */
   pageArrangement?: 'column' | 'wrapped';
+  /** Current visual page scale used by the outer viewport transform. */
+  pageScale?: number;
 }
 
 export interface HeaderFooterLayoutInfo {
@@ -1773,9 +1775,11 @@ function computeOptionsHash(options: RenderPageOptions): string {
 function applyContainerStyles(
   container: HTMLElement,
   pageGap: number,
-  pageArrangement: 'column' | 'wrapped' = 'column'
+  pageArrangement: 'column' | 'wrapped' = 'column',
+  pageScale = 1
 ): void {
   const isWrapped = pageArrangement === 'wrapped';
+  const effectiveScale = Math.max(pageScale, 0.01);
   container.style.display = 'flex';
   container.style.flexDirection = isWrapped ? 'row' : 'column';
   container.style.flexWrap = isWrapped ? 'wrap' : 'nowrap';
@@ -1784,7 +1788,7 @@ function applyContainerStyles(
   container.style.alignContent = isWrapped ? 'flex-start' : '';
   container.style.gap = `${pageGap}px`;
   container.style.padding = `${pageGap}px`;
-  container.style.width = '100%';
+  container.style.width = isWrapped ? `${100 / effectiveScale}%` : '100%';
   container.style.boxSizing = 'border-box';
   container.style.backgroundColor = 'var(--doc-bg, #f8f9fa)';
 }
@@ -1828,6 +1832,8 @@ export function renderPages(
   const prevState = pc.__pageRenderState;
   const currentOptionsHash = computeOptionsHash(options);
   const useVirtualization = totalPages >= VIRTUALIZATION_THRESHOLD;
+
+  applyContainerStyles(container, pageGap, options.pageArrangement, options.pageScale ?? 1);
 
   // Determine if we can do an incremental update
   const canIncremental =
@@ -1948,8 +1954,6 @@ export function renderPages(
   // Clear existing content
   container.innerHTML = '';
   pc.__pageRenderState = undefined;
-
-  applyContainerStyles(container, pageGap, options.pageArrangement);
 
   // Build all page shells
   const pageShells: HTMLElement[] = [];

--- a/packages/react/i18n/de.json
+++ b/packages/react/i18n/de.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "Zoom: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "Farbauswahl — {type}",
     "highlightColors": "Hervorhebungsfarben",

--- a/packages/react/i18n/en.json
+++ b/packages/react/i18n/en.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "Zoom: {label}"
   },
+  "pageView": {
+    "ariaLabel": "Page view: {label}",
+    "title": "Page view: {label}",
+    "onePage": "One Page",
+    "multiplePages": "Multiple Pages",
+    "pageWidth": "Page Width"
+  },
   "colorPicker": {
     "ariaLabel": "{type} color picker",
     "highlightColors": "Highlight Colors",

--- a/packages/react/i18n/he.json
+++ b/packages/react/i18n/he.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "זום: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "בחר צבע {type}",
     "highlightColors": "צבע סימון",

--- a/packages/react/i18n/pl.json
+++ b/packages/react/i18n/pl.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "Powiększenie: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "Próbnik kolorów — {type}",
     "highlightColors": "Kolory wyróżnienia",

--- a/packages/react/i18n/pt-BR.json
+++ b/packages/react/i18n/pt-BR.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "Zoom: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "Seletor de cores {type}",
     "highlightColors": "Cores de destaque",

--- a/packages/react/i18n/tr.json
+++ b/packages/react/i18n/tr.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "Yakınlaştırma: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "{type} renk seçici",
     "highlightColors": "Vurgu renkleri",

--- a/packages/react/i18n/zh-CN.json
+++ b/packages/react/i18n/zh-CN.json
@@ -127,6 +127,13 @@
   "zoom": {
     "ariaLabel": "缩放: {label}"
   },
+  "pageView": {
+    "ariaLabel": null,
+    "title": null,
+    "onePage": null,
+    "multiplePages": null,
+    "pageWidth": null
+  },
   "colorPicker": {
     "ariaLabel": "{type} 颜色选择器",
     "highlightColors": "突出显示颜色",

--- a/packages/react/src/components/CommentMarginMarkers.tsx
+++ b/packages/react/src/components/CommentMarginMarkers.tsx
@@ -15,6 +15,10 @@ export interface CommentMarginMarkersProps {
   anchorPositions: Map<string, number>;
   zoom: number;
   pageWidth: number;
+  /** Optional per-comment rendered page rail x-position. */
+  railLefts?: Map<number, number>;
+  /** Optional fallback rendered page rail x-position. */
+  railLeft?: number;
   sidebarOpen: boolean;
   resolvedCommentIds: Set<number>;
   onMarkerClick: (commentId: number) => void;
@@ -25,15 +29,23 @@ export function CommentMarginMarkers({
   anchorPositions,
   zoom,
   pageWidth,
+  railLefts,
+  railLeft,
   sidebarOpen,
   resolvedCommentIds,
   onMarkerClick,
 }: CommentMarginMarkersProps) {
   const { t } = useTranslation();
   const rootComments = comments.filter((c) => c.parentId == null);
+  type CommentMarker = {
+    comment: Comment;
+    isResolved: boolean;
+    y: number;
+    railLeft?: number;
+  };
 
   const markers = rootComments
-    .map((comment) => {
+    .map<CommentMarker | null>((comment) => {
       const isResolved = resolvedCommentIds.has(comment.id);
       // Active: hide when sidebar is open (card visible in sidebar)
       if (!isResolved && sidebarOpen) return null;
@@ -41,11 +53,12 @@ export function CommentMarginMarkers({
       if (isResolved && sidebarOpen) return null;
       const y = anchorPositions.get(`comment-${comment.id}`);
       if (y == null) return null;
-      return { comment, isResolved, y };
+      return { comment, isResolved, y, railLeft: railLefts?.get(comment.id) ?? railLeft };
     })
-    .filter(Boolean) as { comment: Comment; isResolved: boolean; y: number }[];
+    .filter((marker): marker is CommentMarker => marker != null);
 
   if (markers.length === 0) return null;
+  const hasPageAwareRails = markers.some((marker) => marker.railLeft != null);
 
   return (
     <div
@@ -54,13 +67,13 @@ export function CommentMarginMarkers({
         position: 'absolute',
         top: 0,
         // Position just past the page right edge
-        left: `calc(50% + ${(pageWidth * zoom) / 2 + 6}px)`,
+        left: hasPageAwareRails ? 0 : `calc(50% + ${(pageWidth * zoom) / 2 + 6}px)`,
         zIndex: 30,
         pointerEvents: 'none',
       }}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      {markers.map(({ comment, isResolved, y }) => (
+      {markers.map(({ comment, isResolved, y, railLeft }) => (
         <button
           key={comment.id}
           onClick={() => onMarkerClick(comment.id)}
@@ -68,7 +81,6 @@ export function CommentMarginMarkers({
           style={{
             position: 'absolute',
             top: y * zoom,
-            left: 0,
             width: 24,
             height: 24,
             display: 'flex',
@@ -81,6 +93,7 @@ export function CommentMarginMarkers({
             pointerEvents: 'auto',
             color: '#5f6368',
             padding: 0,
+            left: hasPageAwareRails ? (railLeft ?? 0) : 0,
             fontFamily: 'inherit',
           }}
           onMouseOver={(e) => {

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -34,6 +34,7 @@ import {
   ToolbarSeparator,
   type SelectionFormatting,
   type FormattingAction,
+  type DocumentViewMode,
 } from './Toolbar';
 import type { FontOption } from './ui/FontPicker';
 import { EditorToolbar } from './EditorToolbar';
@@ -281,6 +282,8 @@ export interface DocxEditorProps {
   showToolbar?: boolean;
   /** Whether to show zoom control (default: true) */
   showZoomControl?: boolean;
+  /** Whether to show page view mode control (default: true) */
+  showPageViewModeControl?: boolean;
   /** Whether to show page margin guides/boundaries (default: false) */
   showMarginGuides?: boolean;
   /** Color for margin guides (default: '#c0c0c0') */
@@ -291,6 +294,8 @@ export interface DocxEditorProps {
   rulerUnit?: 'inch' | 'cm';
   /** Initial zoom level (default: 1.0) */
   initialZoom?: number;
+  /** Initial page view mode (default: 'onePage') */
+  initialDocumentViewMode?: DocumentViewMode;
   /** Whether the editor is read-only. When true, hides toolbar and rulers */
   readOnly?: boolean;
   /**
@@ -568,6 +573,7 @@ interface EditorState {
   isLoading: boolean;
   parseError: string | null;
   zoom: number;
+  documentViewMode: DocumentViewMode;
   /** Current selection formatting for toolbar */
   selectionFormatting: SelectionFormatting;
   /** Paragraph indent data for ruler */
@@ -1263,11 +1269,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     theme,
     showToolbar = true,
     showZoomControl = true,
+    showPageViewModeControl = true,
     showMarginGuides: _showMarginGuides = false,
     marginGuideColor: _marginGuideColor,
     showRuler = false,
     rulerUnit = 'inch',
     initialZoom = 1.0,
+    initialDocumentViewMode = 'onePage',
     readOnly: readOnlyProp = false,
     disableFindReplaceShortcuts = false,
     toolbarExtra,
@@ -1315,6 +1323,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     isLoading: !!documentBuffer && !externalContent,
     parseError: null,
     zoom: initialZoom,
+    documentViewMode: initialDocumentViewMode,
     selectionFormatting: {},
     paragraphIndentLeft: 0,
     paragraphIndentRight: 0,
@@ -2941,7 +2950,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   // Handle zoom change
   const handleZoomChange = useCallback((zoom: number) => {
-    setState((prev) => ({ ...prev, zoom }));
+    setState((prev) => ({
+      ...prev,
+      zoom,
+      documentViewMode: prev.documentViewMode === 'pageWidth' ? 'onePage' : prev.documentViewMode,
+    }));
   }, []);
 
   // Handle hyperlink dialog submit
@@ -3544,25 +3557,43 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       const layout = pagedEditorRef.current?.getLayout();
       if (!layout || layout.pages.length === 0) return;
 
-      const scrollTop = scrollContainerEl.scrollTop;
       const totalPages = layout.pages.length;
-      const pageGap = 24; // DEFAULT_PAGE_GAP from PagedEditor
-      const paddingTop = 24; // top padding in paged-editor__pages
-
-      // Calculate which page is visible at the viewport center
-      const viewportCenter = scrollTop + scrollContainerEl.clientHeight / 2;
-      let accumulatedY = paddingTop;
+      const pages = Array.from(
+        scrollContainerEl.querySelectorAll<HTMLElement>('.paged-editor__pages .layout-page')
+      );
       let currentPage = 1;
+      if (pages.length > 0) {
+        const viewportRect = scrollContainerEl.getBoundingClientRect();
+        const viewportCenterY = viewportRect.top + viewportRect.height / 2;
+        let bestPageNumber = 1;
+        let bestVisibleArea = -1;
+        let bestCenterDistance = Number.POSITIVE_INFINITY;
 
-      for (let i = 0; i < layout.pages.length; i++) {
-        const pageHeight = layout.pages[i].size.h;
-        const pageEnd = accumulatedY + pageHeight;
-        if (viewportCenter < pageEnd) {
-          currentPage = i + 1;
-          break;
+        for (let i = 0; i < pages.length; i++) {
+          const pageRect = pages[i].getBoundingClientRect();
+          const visibleWidth = Math.max(
+            0,
+            Math.min(pageRect.right, viewportRect.right) -
+              Math.max(pageRect.left, viewportRect.left)
+          );
+          const visibleHeight = Math.max(
+            0,
+            Math.min(pageRect.bottom, viewportRect.bottom) -
+              Math.max(pageRect.top, viewportRect.top)
+          );
+          const visibleArea = visibleWidth * visibleHeight;
+          const centerDistance = Math.abs(pageRect.top + pageRect.height / 2 - viewportCenterY);
+
+          if (
+            visibleArea > bestVisibleArea ||
+            (visibleArea === bestVisibleArea && centerDistance < bestCenterDistance)
+          ) {
+            bestVisibleArea = visibleArea;
+            bestCenterDistance = centerDistance;
+            bestPageNumber = Number(pages[i].dataset.pageNumber) || i + 1;
+          }
         }
-        accumulatedY = pageEnd + pageGap;
-        currentPage = i + 2; // next page
+        currentPage = bestPageNumber;
       }
       currentPage = Math.min(currentPage, totalPages);
 
@@ -3579,13 +3610,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     };
 
     scrollContainerEl.addEventListener('scroll', handleScroll, { passive: true });
+    const frame = requestAnimationFrame(handleScroll);
     return () => {
+      cancelAnimationFrame(frame);
       scrollContainerEl.removeEventListener('scroll', handleScroll);
       if (scrollFadeTimerRef.current) {
         clearTimeout(scrollFadeTimerRef.current);
       }
     };
-  }, [scrollContainerEl]);
+  }, [scrollContainerEl, state.documentViewMode]);
 
   // Handle save
   const handleSave = useCallback(
@@ -3929,7 +3962,13 @@ body { background: white; }
       getDocument: () => history.state,
       getEditorRef: () => pagedEditorRef.current,
       save: handleSave,
-      setZoom: (zoom: number) => setState((prev) => ({ ...prev, zoom })),
+      setZoom: (zoom: number) =>
+        setState((prev) => ({
+          ...prev,
+          zoom,
+          documentViewMode:
+            prev.documentViewMode === 'pageWidth' ? 'onePage' : prev.documentViewMode,
+        })),
       getZoom: () => state.zoom,
       focus: () => {
         pagedEditorRef.current?.focus();
@@ -4801,6 +4840,49 @@ body { background: white; }
     ? Math.round(sectionPropsPageWidth / 15)
     : DEFAULT_PAGE_WIDTH;
 
+  const calculatePageWidthZoom = useCallback((): number | null => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer || pageWidthPx <= 0) return null;
+
+    const sidebarAllowance = sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0;
+    const availableWidth =
+      scrollContainer.clientWidth - 2 * outlineLeftAllowance - sidebarAllowance - 48;
+    const fitZoom = availableWidth / pageWidthPx;
+    return Math.max(0.25, Math.min(2, Math.round(fitZoom * 100) / 100));
+  }, [outlineLeftAllowance, pageWidthPx, sidebarOpen]);
+
+  const applyPageWidthZoom = useCallback(() => {
+    const fitZoom = calculatePageWidthZoom();
+    if (fitZoom == null) return;
+    setState((prev) => (prev.zoom === fitZoom ? prev : { ...prev, zoom: fitZoom }));
+  }, [calculatePageWidthZoom]);
+
+  const handleDocumentViewModeChange = useCallback(
+    (mode: DocumentViewMode) => {
+      setState((prev) => ({ ...prev, documentViewMode: mode }));
+      if (mode === 'pageWidth') {
+        requestAnimationFrame(applyPageWidthZoom);
+      }
+    },
+    [applyPageWidthZoom]
+  );
+
+  useEffect(() => {
+    if (state.documentViewMode !== 'pageWidth') return;
+    applyPageWidthZoom();
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const observer = new ResizeObserver(applyPageWidthZoom);
+    observer.observe(scrollContainer);
+    window.addEventListener('resize', applyPageWidthZoom);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', applyPageWidthZoom);
+    };
+  }, [applyPageWidthZoom, state.documentViewMode]);
+
   const resolvedCommentIds = useMemo(() => {
     const ids = new Set<number>();
     for (const c of comments) {
@@ -4955,6 +5037,9 @@ body { background: white; }
                       showZoomControl={showZoomControl}
                       zoom={state.zoom}
                       onZoomChange={handleZoomChange}
+                      showPageViewModeControl={showPageViewModeControl}
+                      documentViewMode={state.documentViewMode}
+                      onDocumentViewModeChange={handleDocumentViewModeChange}
                       onRefocusEditor={focusActiveEditor}
                       onInsertTable={handleInsertTable}
                       showTableInsert={true}
@@ -5150,6 +5235,7 @@ body { background: white; }
                         hfEditMode={hfEditPosition}
                         onBodyClick={handleBodyClick}
                         zoom={state.zoom}
+                        pageViewMode={state.documentViewMode}
                         readOnly={readOnly}
                         extensionManager={extensionManager}
                         onDocumentChange={handleDocumentChange}

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -45,7 +45,7 @@ import {
   OUTLINE_BUTTON_RESERVED_SPACE,
   OUTLINE_RESERVED_SPACE,
 } from './DocumentOutline';
-import { SIDEBAR_DOCUMENT_SHIFT } from './sidebar/constants';
+import { SIDEBAR_DOCUMENT_SHIFT, SIDEBAR_PAGE_GAP } from './sidebar/constants';
 import { UnifiedSidebar } from './UnifiedSidebar';
 import { AgentPanel } from './AgentPanel';
 import { CommentMarginMarkers } from './CommentMarginMarkers';
@@ -1083,18 +1083,52 @@ function injectTCReplyRangeMarkers(content: BlockContent[], comments: Comment[])
 }
 
 const EMPTY_ANCHOR_POSITIONS = new Map<string, number>();
+const EMPTY_COMMENT_RAIL_LEFTS = new Map<number, number>();
 
-/**
- * Find the Y position (relative to parentEl) of the element containing the given PM position.
- * Used by both the floating comment button and the context menu comment action.
- * Queries all elements with data-pm-start (spans, divs, imgs) — not just spans,
- * since table cell content may use div fragments.
- */
-function findSelectionYPosition(
+interface VisiblePageGeometry {
+  pageNumber: number;
+  pageIndex: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  contentLeft: number;
+}
+
+interface SelectionAnchorGeometry {
+  top: number;
+  page: VisiblePageGeometry;
+}
+
+function pageGeometryFromElement(
+  pageEl: HTMLElement,
+  scrollContainer: HTMLElement,
+  parentEl: HTMLElement
+): VisiblePageGeometry {
+  const pageRect = pageEl.getBoundingClientRect();
+  const parentRect = parentEl.getBoundingClientRect();
+  const scrollRect = scrollContainer.getBoundingClientRect();
+  const pageNumber = Number(pageEl.dataset.pageNumber) || 1;
+  return {
+    pageNumber,
+    pageIndex: Math.max(0, pageNumber - 1),
+    left: pageRect.left - parentRect.left,
+    right: pageRect.right - parentRect.left,
+    top: pageRect.top - parentRect.top,
+    bottom: pageRect.bottom - parentRect.top,
+    width: pageRect.width,
+    height: pageRect.height,
+    contentLeft: pageRect.left - scrollRect.left + scrollContainer.scrollLeft,
+  };
+}
+
+function pageGeometryForPmPosition(
   scrollContainer: HTMLElement | null,
   parentEl: HTMLElement | null,
   pmPos: number
-): number | null {
+): VisiblePageGeometry | null {
   if (!scrollContainer || !parentEl) return null;
   const pagesEl = scrollContainer.querySelector('.paged-editor__pages');
   if (!pagesEl) return null;
@@ -1102,7 +1136,150 @@ function findSelectionYPosition(
     const pmStart = Number(el.dataset.pmStart);
     const pmEnd = Number(el.dataset.pmEnd);
     if (pmPos >= pmStart && pmPos <= pmEnd) {
-      return el.getBoundingClientRect().top - parentEl.getBoundingClientRect().top;
+      const pageEl = el.closest('.layout-page') as HTMLElement | null;
+      return pageEl ? pageGeometryFromElement(pageEl, scrollContainer, parentEl) : null;
+    }
+  }
+  return null;
+}
+
+function bestVisiblePageGeometry(
+  scrollContainer: HTMLElement | null,
+  parentEl: HTMLElement | null
+): VisiblePageGeometry | null {
+  if (!scrollContainer || !parentEl) return null;
+  const pages = Array.from(
+    scrollContainer.querySelectorAll<HTMLElement>('.paged-editor__pages .layout-page')
+  );
+  if (pages.length === 0) return null;
+
+  const viewportRect = scrollContainer.getBoundingClientRect();
+  let bestPage: HTMLElement | null = null;
+  let bestVisibleTop = Number.POSITIVE_INFINITY;
+  let bestLeft = Number.POSITIVE_INFINITY;
+  let bestVisibleArea = -1;
+  const geometryTolerance = 0.5;
+
+  for (const page of pages) {
+    const pageRect = page.getBoundingClientRect();
+    const visibleWidth = Math.max(
+      0,
+      Math.min(pageRect.right, viewportRect.right) - Math.max(pageRect.left, viewportRect.left)
+    );
+    const visibleHeight = Math.max(
+      0,
+      Math.min(pageRect.bottom, viewportRect.bottom) - Math.max(pageRect.top, viewportRect.top)
+    );
+    const visibleArea = visibleWidth * visibleHeight;
+    if (visibleArea <= 0) continue;
+    const visibleTop = Math.max(pageRect.top, viewportRect.top);
+    const left = pageRect.left;
+
+    if (
+      visibleTop < bestVisibleTop - geometryTolerance ||
+      (Math.abs(visibleTop - bestVisibleTop) <= geometryTolerance &&
+        left < bestLeft - geometryTolerance) ||
+      (Math.abs(visibleTop - bestVisibleTop) <= geometryTolerance &&
+        Math.abs(left - bestLeft) <= geometryTolerance &&
+        visibleArea > bestVisibleArea)
+    ) {
+      bestPage = page;
+      bestVisibleTop = visibleTop;
+      bestLeft = left;
+      bestVisibleArea = visibleArea;
+    }
+  }
+
+  return bestPage ? pageGeometryFromElement(bestPage, scrollContainer, parentEl) : null;
+}
+
+function collectCommentRailLefts(
+  scrollContainer: HTMLElement | null,
+  parentEl: HTMLElement | null
+): Map<number, number> {
+  if (!scrollContainer || !parentEl) return EMPTY_COMMENT_RAIL_LEFTS;
+  const pagesEl = scrollContainer.querySelector('.paged-editor__pages');
+  if (!pagesEl) return EMPTY_COMMENT_RAIL_LEFTS;
+  const rails = new Map<number, number>();
+  for (const el of pagesEl.querySelectorAll<HTMLElement>('[data-comment-id]')) {
+    const commentId = Number(el.dataset.commentId);
+    if (Number.isNaN(commentId) || rails.has(commentId)) continue;
+    const pageEl = el.closest('.layout-page') as HTMLElement | null;
+    if (!pageEl) continue;
+    const page = pageGeometryFromElement(pageEl, scrollContainer, parentEl);
+    rails.set(commentId, page.right + 6);
+  }
+  return rails.size > 0 ? rails : EMPTY_COMMENT_RAIL_LEFTS;
+}
+
+function visiblePageGeometryEqual(
+  a: VisiblePageGeometry | null,
+  b: VisiblePageGeometry | null
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.pageNumber === b.pageNumber &&
+    Math.abs(a.left - b.left) < 0.5 &&
+    Math.abs(a.right - b.right) < 0.5 &&
+    Math.abs(a.top - b.top) < 0.5 &&
+    Math.abs(a.width - b.width) < 0.5 &&
+    Math.abs(a.contentLeft - b.contentLeft) < 0.5
+  );
+}
+
+function railLeftsEqual(a: Map<number, number>, b: Map<number, number>): boolean {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    const other = b.get(key);
+    if (other == null || Math.abs(other - value) >= 0.5) return false;
+  }
+  return true;
+}
+
+function sectionPropsFromVisiblePage(
+  page: {
+    size: { w: number; h: number };
+    margins: { top: number; right: number; bottom: number; left: number };
+  },
+  fallback?: SectionProperties | null
+): SectionProperties {
+  return {
+    ...fallback,
+    pageWidth: Math.round(page.size.w * 15),
+    pageHeight: Math.round(page.size.h * 15),
+    marginTop: Math.round(page.margins.top * 15),
+    marginRight: Math.round(page.margins.right * 15),
+    marginBottom: Math.round(page.margins.bottom * 15),
+    marginLeft: Math.round(page.margins.left * 15),
+  };
+}
+
+/**
+ * Find the page-aware position of the element containing the given PM position.
+ * Used by both the floating comment button and the context menu comment action.
+ * Queries all elements with data-pm-start (spans, divs, imgs) — not just spans,
+ * since table cell content may use div fragments.
+ */
+function findSelectionAnchorGeometry(
+  scrollContainer: HTMLElement | null,
+  parentEl: HTMLElement | null,
+  pmPos: number
+): SelectionAnchorGeometry | null {
+  if (!scrollContainer || !parentEl) return null;
+  const pagesEl = scrollContainer.querySelector('.paged-editor__pages');
+  if (!pagesEl) return null;
+  for (const el of findBodyPmAnchors(pagesEl)) {
+    const pmStart = Number(el.dataset.pmStart);
+    const pmEnd = Number(el.dataset.pmEnd);
+    if (pmPos >= pmStart && pmPos <= pmEnd) {
+      const pageEl = el.closest('.layout-page') as HTMLElement | null;
+      if (!pageEl) return null;
+      return {
+        top: el.getBoundingClientRect().top - parentEl.getBoundingClientRect().top,
+        page: pageGeometryFromElement(pageEl, scrollContainer, parentEl),
+      };
     }
   }
   return null;
@@ -1333,6 +1510,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     pmTableContext: null,
     pmImageContext: null,
   });
+  const lastExplicitZoomRef = useRef(initialZoom);
 
   // Table properties dialog state
   const [tablePropsOpen, setTablePropsOpen] = useState(false);
@@ -1662,6 +1840,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     totalPages: number;
     visible: boolean;
   }>({ currentPage: 1, totalPages: 1, visible: false });
+  const [activePageGeometry, setActivePageGeometry] = useState<VisiblePageGeometry | null>(null);
+  const [commentRailLefts, setCommentRailLefts] =
+    useState<Map<number, number>>(EMPTY_COMMENT_RAIL_LEFTS);
   const scrollFadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Measure toolbar height for positioning the outline panel below it
@@ -1927,6 +2108,29 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [onChange, pushDocument, cleanOrphanedComments]
   );
 
+  const refreshPageChromeGeometry = useCallback((preferredPmPos?: number | null) => {
+    const scrollContainer = scrollContainerRef.current;
+    const parentEl = editorContentRef.current;
+    if (!scrollContainer || !parentEl) return null;
+
+    const visiblePage = bestVisiblePageGeometry(scrollContainer, parentEl);
+    const selectedPage =
+      preferredPmPos != null
+        ? pageGeometryForPmPosition(scrollContainer, parentEl, preferredPmPos)
+        : null;
+    const activePage = visiblePage ?? selectedPage;
+    const nextCommentRails = collectCommentRailLefts(scrollContainer, parentEl);
+
+    setActivePageGeometry((prev) =>
+      visiblePageGeometryEqual(prev, activePage) ? prev : activePage
+    );
+    setCommentRailLefts((prev) =>
+      railLeftsEqual(prev, nextCommentRails) ? prev : nextCommentRails
+    );
+
+    return selectedPage ?? activePage;
+  }, []);
+
   // Recompute the floating "add comment" button position from the current PM
   // selection + page/container geometry. Called from handleSelectionChange and
   // from the geometry-change effects below (resize, zoom), because PagedEditor's
@@ -1948,15 +2152,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     const container = scrollContainerRef.current;
     const parentEl = editorContentRef.current;
     if (!container || !parentEl) return;
-    const top = findSelectionYPosition(container, parentEl, from);
-    if (top == null) return;
-    const pagesEl = container.querySelector('.paged-editor__pages');
-    const pageEl = pagesEl?.querySelector('.layout-page') as HTMLElement | null;
-    const left = pageEl
-      ? pageEl.getBoundingClientRect().right - parentEl.getBoundingClientRect().left
-      : parentEl.getBoundingClientRect().width / 2 + 408;
-    setFloatingCommentBtn({ top, left });
-  }, []);
+    const anchor = findSelectionAnchorGeometry(container, parentEl, from);
+    const activePage = refreshPageChromeGeometry(from);
+    const page = anchor?.page ?? activePage;
+    if (!anchor || !page) return;
+    setFloatingCommentBtn({ top: anchor.top, left: page.right });
+  }, [refreshPageChromeGeometry]);
   // Keep the readOnly ref used by recomputeFloatingCommentBtn in sync
   readOnlyForFloatingBtnRef.current = readOnly;
 
@@ -1971,18 +2172,49 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
-    const ro = new ResizeObserver(() => recomputeFloatingCommentBtn());
+    const updateGeometry = () => {
+      recomputeFloatingCommentBtn();
+      refreshPageChromeGeometry();
+    };
+    const ro = new ResizeObserver(updateGeometry);
     ro.observe(container);
-    const onWinResize = () => recomputeFloatingCommentBtn();
+    const onWinResize = updateGeometry;
     window.addEventListener('resize', onWinResize);
     return () => {
       ro.disconnect();
       window.removeEventListener('resize', onWinResize);
     };
-  }, [state.isLoading, recomputeFloatingCommentBtn]);
+  }, [state.isLoading, recomputeFloatingCommentBtn, refreshPageChromeGeometry]);
   useEffect(() => {
-    recomputeFloatingCommentBtn();
-  }, [state.zoom, recomputeFloatingCommentBtn]);
+    const updateGeometry = () => {
+      recomputeFloatingCommentBtn();
+      refreshPageChromeGeometry();
+    };
+    const container = scrollContainerRef.current;
+    const viewportEl = container?.querySelector('.paged-editor__pages')?.parentElement;
+    let settleFrame: number | null = null;
+    const frame = requestAnimationFrame(() => {
+      updateGeometry();
+      settleFrame = requestAnimationFrame(updateGeometry);
+    });
+    const settleInterval = window.setInterval(updateGeometry, 100);
+    const settleTimer = window.setTimeout(() => {
+      window.clearInterval(settleInterval);
+      updateGeometry();
+    }, 1200);
+    const onTransitionEnd = (event: Event) => {
+      if (event instanceof TransitionEvent && event.propertyName !== 'transform') return;
+      updateGeometry();
+    };
+    viewportEl?.addEventListener('transitionend', onTransitionEnd);
+    return () => {
+      cancelAnimationFrame(frame);
+      if (settleFrame != null) cancelAnimationFrame(settleFrame);
+      window.clearInterval(settleInterval);
+      window.clearTimeout(settleTimer);
+      viewportEl?.removeEventListener('transitionend', onTransitionEnd);
+    };
+  }, [state.zoom, state.documentViewMode, recomputeFloatingCommentBtn, refreshPageChromeGeometry]);
 
   // Handle selection changes from ProseMirror
   const handleSelectionChange = useCallback(
@@ -2115,6 +2347,17 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
       // Update floating comment button position
       recomputeFloatingCommentBtn();
+      if (view) {
+        const activePage = refreshPageChromeGeometry(view.state.selection.from);
+        if (activePage) {
+          const totalPages = pagedEditorRef.current?.getLayout()?.pages.length ?? 1;
+          setScrollPageInfo((prev) => ({
+            ...prev,
+            currentPage: Math.min(activePage.pageNumber, totalPages),
+            totalPages,
+          }));
+        }
+      }
 
       // Notify parent
       onSelectionChange?.(selectionState);
@@ -2129,7 +2372,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     },
     // getActiveEditorView's return depends on hfEditPosition; theme drives
     // color resolution. Both must be in deps to avoid stale-closure reads.
-    [onSelectionChange, isAddingComment, readOnly, getActiveEditorView, theme]
+    [
+      onSelectionChange,
+      isAddingComment,
+      readOnly,
+      getActiveEditorView,
+      theme,
+      recomputeFloatingCommentBtn,
+      refreshPageChromeGeometry,
+    ]
   );
 
   // Table selection hook
@@ -2950,6 +3201,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   // Handle zoom change
   const handleZoomChange = useCallback((zoom: number) => {
+    lastExplicitZoomRef.current = zoom;
     setState((prev) => ({
       ...prev,
       zoom,
@@ -3419,11 +3671,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           if (from === to) break;
           // Compute Y position BEFORE dispatching — dispatch triggers re-layout
           // which rebuilds page DOM and invalidates the old span elements
-          const yPos = findSelectionYPosition(
+          const anchor = findSelectionAnchorGeometry(
             scrollContainerRef.current,
             editorContentRef.current,
             from
           );
+          refreshPageChromeGeometry(from);
           setCommentSelectionRange({ from, to });
           const pendingMark = view.state.schema.marks.comment.create({
             commentId: PENDING_COMMENT_ID,
@@ -3431,7 +3684,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           const tr = view.state.tr.addMark(from, to, pendingMark);
           tr.setSelection(TextSelection.create(tr.doc, to));
           view.dispatch(tr);
-          setAddCommentYPosition(yPos);
+          setAddCommentYPosition(anchor?.top ?? null);
           setShowCommentsSidebar(true);
           setIsAddingComment(true);
           setFloatingCommentBtn(null);
@@ -3440,7 +3693,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       }
       // TextContextMenu calls onClose after onAction, so no need to close here
     },
-    [getActiveEditorView, focusActiveEditor, openSplitCellDialog]
+    [getActiveEditorView, focusActiveEditor, openSplitCellDialog, refreshPageChromeGeometry]
   );
 
   // Handle margin changes from rulers
@@ -3558,43 +3811,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       if (!layout || layout.pages.length === 0) return;
 
       const totalPages = layout.pages.length;
-      const pages = Array.from(
-        scrollContainerEl.querySelectorAll<HTMLElement>('.paged-editor__pages .layout-page')
-      );
-      let currentPage = 1;
-      if (pages.length > 0) {
-        const viewportRect = scrollContainerEl.getBoundingClientRect();
-        const viewportCenterY = viewportRect.top + viewportRect.height / 2;
-        let bestPageNumber = 1;
-        let bestVisibleArea = -1;
-        let bestCenterDistance = Number.POSITIVE_INFINITY;
-
-        for (let i = 0; i < pages.length; i++) {
-          const pageRect = pages[i].getBoundingClientRect();
-          const visibleWidth = Math.max(
-            0,
-            Math.min(pageRect.right, viewportRect.right) -
-              Math.max(pageRect.left, viewportRect.left)
-          );
-          const visibleHeight = Math.max(
-            0,
-            Math.min(pageRect.bottom, viewportRect.bottom) -
-              Math.max(pageRect.top, viewportRect.top)
-          );
-          const visibleArea = visibleWidth * visibleHeight;
-          const centerDistance = Math.abs(pageRect.top + pageRect.height / 2 - viewportCenterY);
-
-          if (
-            visibleArea > bestVisibleArea ||
-            (visibleArea === bestVisibleArea && centerDistance < bestCenterDistance)
-          ) {
-            bestVisibleArea = visibleArea;
-            bestCenterDistance = centerDistance;
-            bestPageNumber = Number(pages[i].dataset.pageNumber) || i + 1;
-          }
-        }
-        currentPage = bestPageNumber;
-      }
+      const pageGeometry = refreshPageChromeGeometry();
+      let currentPage = pageGeometry?.pageNumber ?? 1;
       currentPage = Math.min(currentPage, totalPages);
 
       setScrollPageInfo({ currentPage, totalPages, visible: true });
@@ -3618,7 +3836,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         clearTimeout(scrollFadeTimerRef.current);
       }
     };
-  }, [scrollContainerEl, state.documentViewMode]);
+  }, [scrollContainerEl, state.documentViewMode, refreshPageChromeGeometry]);
 
   // Handle save
   const handleSave = useCallback(
@@ -3962,13 +4180,15 @@ body { background: white; }
       getDocument: () => history.state,
       getEditorRef: () => pagedEditorRef.current,
       save: handleSave,
-      setZoom: (zoom: number) =>
+      setZoom: (zoom: number) => {
+        lastExplicitZoomRef.current = zoom;
         setState((prev) => ({
           ...prev,
           zoom,
           documentViewMode:
             prev.documentViewMode === 'pageWidth' ? 'onePage' : prev.documentViewMode,
-        })),
+        }));
+      },
       getZoom: () => state.zoom,
       focus: () => {
         pagedEditorRef.current?.focus();
@@ -4839,6 +5059,18 @@ body { background: white; }
   const pageWidthPx = sectionPropsPageWidth
     ? Math.round(sectionPropsPageWidth / 15)
     : DEFAULT_PAGE_WIDTH;
+  const activeLayoutPage =
+    activePageGeometry != null
+      ? (pagedEditorRef.current?.getLayout()?.pages[activePageGeometry.pageIndex] ?? null)
+      : null;
+  const activeRulerSectionProps = activeLayoutPage
+    ? sectionPropsFromVisiblePage(
+        activeLayoutPage,
+        history.state?.package.document?.finalSectionProperties
+      )
+    : history.state?.package.document?.finalSectionProperties;
+  const activeSidebarRailLeft =
+    activePageGeometry != null ? activePageGeometry.right + SIDEBAR_PAGE_GAP : undefined;
 
   const calculatePageWidthZoom = useCallback((): number | null => {
     const scrollContainer = scrollContainerRef.current;
@@ -4859,7 +5091,19 @@ body { background: white; }
 
   const handleDocumentViewModeChange = useCallback(
     (mode: DocumentViewMode) => {
-      setState((prev) => ({ ...prev, documentViewMode: mode }));
+      setState((prev) => {
+        if (mode === 'pageWidth' && prev.documentViewMode !== 'pageWidth') {
+          lastExplicitZoomRef.current = prev.zoom;
+        }
+        if (prev.documentViewMode === 'pageWidth' && mode !== 'pageWidth') {
+          return {
+            ...prev,
+            documentViewMode: mode,
+            zoom: lastExplicitZoomRef.current,
+          };
+        }
+        return { ...prev, documentViewMode: mode };
+      });
       if (mode === 'pageWidth') {
         requestAnimationFrame(applyPageWidthZoom);
       }
@@ -5102,43 +5346,49 @@ body { background: white; }
                       viewport is too narrow to fit page + outline + sidebar. */}
                   {showRuler && (
                     <div
-                      className="flex justify-center py-1 flex-shrink-0 bg-doc-bg"
+                      className="py-1 flex-shrink-0 bg-doc-bg"
                       style={{
                         position: 'sticky',
                         top: 0,
+                        display: activePageGeometry ? 'block' : 'flex',
+                        justifyContent: activePageGeometry ? undefined : 'center',
                         // Must sit above the inline header/footer editor
                         // (Z_INDEX.hfInlineEditor) so the ruler stays readable
                         // when the HF editor is active near the viewport top.
                         zIndex: Z_INDEX.ruler,
-                        // paddingRight biases the centered ruler so it tracks
-                        // the page when the comments sidebar (translateX)
-                        // shifts the page left. Outline doesn't bias here —
-                        // the page stays centered until minLayoutWidth forces
-                        // horizontal scroll, and the ruler centers with it.
-                        paddingLeft: 20,
-                        paddingRight: 20 + (sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0),
                         minWidth: minLayoutWidth,
                         transition: 'padding 0.2s ease',
                       }}
                     >
-                      <HorizontalRuler
-                        sectionProps={history.state?.package.document?.finalSectionProperties}
-                        zoom={state.zoom}
-                        unit={rulerUnit}
-                        editable={!readOnly}
-                        onLeftMarginChange={handleLeftMarginChange}
-                        onRightMarginChange={handleRightMarginChange}
-                        indentLeft={state.paragraphIndentLeft}
-                        indentRight={state.paragraphIndentRight}
-                        onIndentLeftChange={handleIndentLeftChange}
-                        onIndentRightChange={handleIndentRightChange}
-                        showFirstLineIndent={true}
-                        firstLineIndent={state.paragraphFirstLineIndent}
-                        hangingIndent={state.paragraphHangingIndent}
-                        onFirstLineIndentChange={handleFirstLineIndentChange}
-                        tabStops={state.paragraphTabs}
-                        onTabStopRemove={handleTabStopRemove}
-                      />
+                      <div
+                        style={
+                          activePageGeometry
+                            ? {
+                                marginLeft: activePageGeometry.contentLeft,
+                                width: activePageGeometry.width,
+                              }
+                            : undefined
+                        }
+                      >
+                        <HorizontalRuler
+                          sectionProps={activeRulerSectionProps}
+                          zoom={state.zoom}
+                          unit={rulerUnit}
+                          editable={!readOnly}
+                          onLeftMarginChange={handleLeftMarginChange}
+                          onRightMarginChange={handleRightMarginChange}
+                          indentLeft={state.paragraphIndentLeft}
+                          indentRight={state.paragraphIndentRight}
+                          onIndentLeftChange={handleIndentLeftChange}
+                          onIndentRightChange={handleIndentRightChange}
+                          showFirstLineIndent={true}
+                          firstLineIndent={state.paragraphFirstLineIndent}
+                          hangingIndent={state.paragraphHangingIndent}
+                          onFirstLineIndentChange={handleFirstLineIndentChange}
+                          tabStops={state.paragraphTabs}
+                          onTabStopRemove={handleTabStopRemove}
+                        />
+                      </div>
                     </div>
                   )}
                   {/* Editor content wrapper. min-width matches the ruler so
@@ -5195,7 +5445,7 @@ body { background: white; }
                           }}
                         >
                           <VerticalRuler
-                            sectionProps={initialSectionProperties}
+                            sectionProps={activeRulerSectionProps ?? initialSectionProperties}
                             zoom={state.zoom}
                             unit={rulerUnit}
                             editable={!readOnly}
@@ -5328,6 +5578,7 @@ body { background: white; }
                                 renderedDomContext={pluginRenderedDomContext ?? null}
                                 pageWidth={pageWidthPx}
                                 zoom={state.zoom}
+                                railLeft={activeSidebarRailLeft}
                                 editorContainerRef={scrollContainerRef}
                                 onExpandedItemChange={setExpandedSidebarItem}
                                 activeItemId={expandedSidebarItem}
@@ -5338,6 +5589,10 @@ body { background: white; }
                               anchorPositions={anchorPositions}
                               zoom={state.zoom}
                               pageWidth={pageWidthPx}
+                              railLefts={commentRailLefts}
+                              railLeft={
+                                activePageGeometry ? activePageGeometry.right + 6 : undefined
+                              }
                               sidebarOpen={sidebarOpen}
                               resolvedCommentIds={resolvedCommentIds}
                               onMarkerClick={() => {

--- a/packages/react/src/components/FormattingBar.tsx
+++ b/packages/react/src/components/FormattingBar.tsx
@@ -20,6 +20,7 @@ import { LineSpacingPicker } from './ui/LineSpacingPicker';
 import { StylePicker } from './ui/StylePicker';
 import { MaterialSymbol } from './ui/MaterialSymbol';
 import { ZoomControl } from './ui/ZoomControl';
+import { PageViewModeControl } from './ui/PageViewModeControl';
 import { TableBorderPicker } from './ui/TableBorderPicker';
 import { TableBorderColorPicker } from './ui/TableBorderColorPicker';
 import { TableBorderWidthPicker } from './ui/TableBorderWidthPicker';
@@ -99,6 +100,9 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
     showZoomControl = true,
     zoom,
     onZoomChange,
+    showPageViewModeControl = true,
+    documentViewMode = 'onePage',
+    onDocumentViewModeChange,
     onRefocusEditor,
     imageContext,
     onImageWrapType,
@@ -380,18 +384,28 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
         </ToolbarButton>
       </ToolbarGroup>
 
-      {/* Zoom Control */}
-      {showZoomControl && (
+      {/* Zoom and page view controls */}
+      {(showZoomControl || showPageViewModeControl) && (
         <ToolbarGroup label={t('formattingBar.groups.zoom')}>
-          <ZoomControl
-            value={zoom}
-            onChange={onZoomChange}
-            minZoom={0.5}
-            maxZoom={2}
-            disabled={disabled}
-            compact
-            showButtons={false}
-          />
+          {showZoomControl && (
+            <ZoomControl
+              value={zoom}
+              onChange={onZoomChange}
+              minZoom={0.5}
+              maxZoom={2}
+              disabled={disabled}
+              compact
+              showButtons={false}
+            />
+          )}
+          {showPageViewModeControl && (
+            <PageViewModeControl
+              value={documentViewMode}
+              onChange={onDocumentViewModeChange}
+              onRefocusEditor={onRefocusEditor}
+              disabled={disabled}
+            />
+          )}
         </ToolbarGroup>
       )}
 

--- a/packages/react/src/components/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar.tsx
@@ -101,6 +101,11 @@ export type FormattingAction =
   | { type: 'applyStyle'; value: string };
 
 /**
+ * Page viewing mode for the visible paginated canvas.
+ */
+export type DocumentViewMode = 'onePage' | 'multiplePages' | 'pageWidth';
+
+/**
  * Props for the Toolbar component
  */
 export interface ToolbarProps {
@@ -169,6 +174,12 @@ export interface ToolbarProps {
   zoom?: number;
   /** Callback when zoom changes */
   onZoomChange?: (zoom: number) => void;
+  /** Whether to show the page view mode control (default: true) */
+  showPageViewModeControl?: boolean;
+  /** Current document page view mode */
+  documentViewMode?: DocumentViewMode;
+  /** Callback when document page view mode changes */
+  onDocumentViewModeChange?: (mode: DocumentViewMode) => void;
   /** Callback to refocus the editor after toolbar interactions */
   onRefocusEditor?: () => void;
   /** Callback when a table should be inserted */

--- a/packages/react/src/components/UnifiedSidebar.tsx
+++ b/packages/react/src/components/UnifiedSidebar.tsx
@@ -19,6 +19,8 @@ export interface UnifiedSidebarProps {
   renderedDomContext: RenderedDomContext | null;
   pageWidth: number;
   zoom: number;
+  /** Optional rendered page rail x-position, relative to the editor viewport. */
+  railLeft?: number;
   editorContainerRef: React.RefObject<HTMLDivElement | null>;
   onExpandedItemChange?: (itemId: string | null) => void;
   /** Controlled: sidebar item to expand based on cursor position. */
@@ -31,6 +33,7 @@ export function UnifiedSidebar({
   renderedDomContext,
   pageWidth,
   zoom,
+  railLeft,
   editorContainerRef,
   onExpandedItemChange,
   activeItemId,
@@ -192,7 +195,10 @@ export function UnifiedSidebar({
       style={{
         position: 'absolute',
         top: 0,
-        left: `calc(50% - ${SIDEBAR_DOCUMENT_SHIFT}px + ${(pageWidth * zoom) / 2 + SIDEBAR_PAGE_GAP}px)`,
+        left:
+          railLeft != null
+            ? railLeft
+            : `calc(50% - ${SIDEBAR_DOCUMENT_SHIFT}px + ${(pageWidth * zoom) / 2 + SIDEBAR_PAGE_GAP}px)`,
         width: SIDEBAR_WIDTH,
         fontFamily: "'Google Sans', Roboto, Arial, sans-serif",
         zIndex: 40,

--- a/packages/react/src/components/ui/Icons.tsx
+++ b/packages/react/src/components/ui/Icons.tsx
@@ -294,6 +294,14 @@ export function IconViewColumn(props: IconProps) {
   );
 }
 
+export function IconArticle(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520Z" />
+    </SvgIcon>
+  );
+}
+
 export function IconBorderAll(props: IconProps) {
   return (
     <SvgIcon {...props}>
@@ -857,6 +865,7 @@ const iconMap: Record<string, React.ComponentType<IconProps>> = {
   grid_on: IconGridOn,
   table_rows: IconTableRows,
   view_column: IconViewColumn,
+  article: IconArticle,
   border_all: IconBorderAll,
   border_outer: IconBorderOuter,
   border_inner: IconBorderInner,

--- a/packages/react/src/components/ui/PageViewModeControl.tsx
+++ b/packages/react/src/components/ui/PageViewModeControl.tsx
@@ -1,0 +1,97 @@
+/**
+ * Page view mode control.
+ *
+ * Compact icon-triggered select for switching how paginated pages are arranged.
+ */
+
+import * as React from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger } from './Select';
+import { MaterialSymbol } from './MaterialSymbol';
+import { cn } from '../../lib/utils';
+import { useTranslation } from '../../i18n';
+import type { DocumentViewMode } from '../Toolbar';
+
+interface PageViewModeOption {
+  value: DocumentViewMode;
+  label: string;
+  iconName: string;
+}
+
+export interface PageViewModeControlProps {
+  value?: DocumentViewMode;
+  onChange?: (mode: DocumentViewMode) => void;
+  onRefocusEditor?: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function PageViewModeControl({
+  value = 'onePage',
+  onChange,
+  onRefocusEditor,
+  disabled = false,
+  className,
+}: PageViewModeControlProps) {
+  const { t } = useTranslation();
+  const options = React.useMemo<PageViewModeOption[]>(
+    () => [
+      {
+        value: 'onePage',
+        label: t('pageView.onePage'),
+        iconName: 'article',
+      },
+      {
+        value: 'multiplePages',
+        label: t('pageView.multiplePages'),
+        iconName: 'view_column',
+      },
+      {
+        value: 'pageWidth',
+        label: t('pageView.pageWidth'),
+        iconName: 'fit_width',
+      },
+    ],
+    [t]
+  );
+  const selected = options.find((option) => option.value === value) ?? options[0];
+
+  const handleValueChange = React.useCallback(
+    (newValue: string) => {
+      if (newValue === 'onePage' || newValue === 'multiplePages' || newValue === 'pageWidth') {
+        onChange?.(newValue);
+        requestAnimationFrame(() => onRefocusEditor?.());
+      }
+    },
+    [onChange, onRefocusEditor]
+  );
+
+  return (
+    <Select value={value} onValueChange={handleValueChange} disabled={disabled}>
+      <SelectTrigger
+        className={cn('h-7 w-[54px] min-w-0 justify-center px-1.5', className)}
+        aria-label={t('pageView.ariaLabel', { label: selected.label })}
+        title={t('pageView.title', { label: selected.label })}
+        data-testid="page-view-mode-control"
+      >
+        <MaterialSymbol name={selected.iconName} size={18} />
+      </SelectTrigger>
+      <SelectContent className="min-w-[180px]">
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value}
+            className="pr-8"
+            data-testid={`page-view-mode-${option.value}`}
+          >
+            <span className="flex items-center gap-2">
+              <MaterialSymbol name={option.iconName} size={18} />
+              <span>{option.label}</span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export default PageViewModeControl;

--- a/packages/react/src/components/ui/ZoomControl.tsx
+++ b/packages/react/src/components/ui/ZoomControl.tsx
@@ -79,12 +79,17 @@ export function ZoomControl({
       <SelectTrigger
         className={cn(compact ? 'h-7 min-w-[55px] text-xs' : 'h-8 min-w-[70px] text-sm', className)}
         aria-label={t('zoom.ariaLabel', { label: displayLabel })}
+        data-testid="zoom-control"
       >
         <SelectValue placeholder="100%">{displayLabel}</SelectValue>
       </SelectTrigger>
       <SelectContent>
         {levels.map((level) => (
-          <SelectItem key={level.value} value={level.value.toString()}>
+          <SelectItem
+            key={level.value}
+            value={level.value.toString()}
+            data-testid={`zoom-level-${Math.round(level.value * 100)}`}
+          >
             {level.label}
           </SelectItem>
         ))}

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -222,6 +222,21 @@ function getPageArrangement(pageViewMode: PageViewMode): PageArrangement {
   return pageViewMode === 'multiplePages' ? 'wrapped' : 'column';
 }
 
+function getWrappedPageScale(pageArrangement: PageArrangement, zoom: number): number {
+  if (pageArrangement !== 'wrapped') return 1;
+  return Math.max(zoom, 0.01);
+}
+
+function getPageArrangementViewportWidth(
+  pageArrangement: PageArrangement,
+  viewportWidth: number,
+  zoom: number
+): number {
+  return pageArrangement === 'wrapped'
+    ? viewportWidth / getWrappedPageScale(pageArrangement, zoom)
+    : viewportWidth;
+}
+
 function computePageVisualOffsets(
   layout: Layout,
   pageGap: number,
@@ -1391,6 +1406,12 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // State
     const [layout, setLayout] = useState<Layout | null>(null);
     const [viewportWidth, setViewportWidth] = useState(0);
+    const wrappedPageScale = getWrappedPageScale(pageArrangement, zoom);
+    const arrangedViewportWidth = getPageArrangementViewportWidth(
+      pageArrangement,
+      viewportWidth,
+      zoom
+    );
     const lastTotalPagesRef = useRef<number>(0);
     const onTotalPagesChangeRef = useRef(onTotalPagesChange);
     onTotalPagesChangeRef.current = onTotalPagesChange;
@@ -1861,6 +1882,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               footnotesByPage: footnotesByPage?.size ? footnotesByPage : undefined,
               resolvedCommentIds,
               pageArrangement,
+              pageScale: wrappedPageScale,
             } as RenderPageOptions & {
               pageGap?: number;
               blockLookup?: BlockLookup;
@@ -1869,7 +1891,12 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
             const vp = viewportLayoutRef.current;
             if (vp) {
-              const mh = viewportMinHeightPx(newLayout, pageGap, pageArrangement, viewportWidth);
+              const mh = viewportMinHeightPx(
+                newLayout,
+                pageGap,
+                pageArrangement,
+                arrangedViewportWidth
+              );
               vp.style.minHeight = `${mh}px`;
               if (zoom !== 1) {
                 vp.style.marginBottom = `${mh * (zoom - 1)}px`;
@@ -1920,7 +1947,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               newLayout,
               pageGap,
               pageArrangement,
-              viewportWidth
+              arrangedViewportWidth
             );
             const positions = computeAnchorPositions(
               hiddenPMRef.current?.getView() ?? null,
@@ -1972,7 +1999,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         resolvedCommentIds,
         getScrollContainer,
         pageArrangement,
-        viewportWidth,
+        arrangedViewportWidth,
+        wrappedPageScale,
       ]
     );
 
@@ -4026,7 +4054,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         layout,
         pageGap,
         pageArrangement,
-        viewportWidth
+        arrangedViewportWidth
       );
       const positions = computeAnchorPositions(
         hiddenPMRef.current?.getView() ?? null,
@@ -4044,7 +4072,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onAnchorPositionsChange,
       pageArrangement,
       pageGap,
-      viewportWidth,
+      arrangedViewportWidth,
     ]);
 
     // Re-compute selection overlay when the container resizes.
@@ -4174,8 +4202,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // Calculate total height for scroll
     const totalHeight = useMemo(() => {
       if (!layout) return DEFAULT_PAGE_HEIGHT + 48;
-      return viewportMinHeightPx(layout, pageGap, pageArrangement, viewportWidth);
-    }, [layout, pageArrangement, pageGap, viewportWidth]);
+      return viewportMinHeightPx(layout, pageGap, pageArrangement, arrangedViewportWidth);
+    }, [layout, pageArrangement, pageGap, arrangedViewportWidth]);
     const renderedPagesContainerStyles = useMemo<CSSProperties>(() => {
       const isWrapped = pageArrangement === 'wrapped';
       return {
@@ -4185,10 +4213,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         justifyContent: isWrapped ? 'center' : undefined,
         alignItems: isWrapped ? 'flex-start' : 'center',
         alignContent: isWrapped ? 'flex-start' : undefined,
-        width: '100%',
+        width: isWrapped ? `${100 / wrappedPageScale}%` : '100%',
         boxSizing: 'border-box',
       };
-    }, [pageArrangement]);
+    }, [pageArrangement, wrappedPageScale]);
 
     return (
       <div

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -210,8 +210,84 @@ function findPaintedPmStartAtOrBefore(pages: HTMLElement, pmPos: number): number
   return best;
 }
 
+export type PageViewMode = 'onePage' | 'multiplePages' | 'pageWidth';
+type PageArrangement = 'column' | 'wrapped';
+
+interface PageVisualOffset {
+  left: number;
+  top: number;
+}
+
+function getPageArrangement(pageViewMode: PageViewMode): PageArrangement {
+  return pageViewMode === 'multiplePages' ? 'wrapped' : 'column';
+}
+
+function computePageVisualOffsets(
+  layout: Layout,
+  pageGap: number,
+  pageArrangement: PageArrangement,
+  viewportWidth: number
+): PageVisualOffset[] {
+  if (pageArrangement === 'column') {
+    let top = 0;
+    return layout.pages.map((page, index) => {
+      const offset = { left: 0, top };
+      top += page.size.h + (index < layout.pages.length - 1 ? pageGap : 0);
+      return offset;
+    });
+  }
+
+  const availableWidth = Math.max(1, viewportWidth - pageGap * 2);
+  const offsets: PageVisualOffset[] = new Array(layout.pages.length);
+  let rowStart = 0;
+  let rowWidth = 0;
+  let rowHeight = 0;
+  let rowTop = 0;
+
+  const flushRow = (exclusiveEnd: number) => {
+    if (exclusiveEnd <= rowStart) return;
+    let left = Math.max(0, (availableWidth - rowWidth) / 2);
+    for (let i = rowStart; i < exclusiveEnd; i++) {
+      const page = layout.pages[i];
+      offsets[i] = { left, top: rowTop };
+      left += page.size.w + pageGap;
+    }
+    rowTop += rowHeight + pageGap;
+    rowStart = exclusiveEnd;
+    rowWidth = 0;
+    rowHeight = 0;
+  };
+
+  for (let i = 0; i < layout.pages.length; i++) {
+    const page = layout.pages[i];
+    const nextWidth = rowWidth === 0 ? page.size.w : rowWidth + pageGap + page.size.w;
+    if (rowWidth > 0 && nextWidth > availableWidth) {
+      flushRow(i);
+    }
+    rowWidth = rowWidth === 0 ? page.size.w : rowWidth + pageGap + page.size.w;
+    rowHeight = Math.max(rowHeight, page.size.h);
+  }
+  flushRow(layout.pages.length);
+
+  return offsets;
+}
+
 /** Min-height of the zoom/viewport wrapper (padding + page stack). Must match JSX `totalHeight`. */
-function viewportMinHeightPx(layout: Layout, pageGap: number): number {
+function viewportMinHeightPx(
+  layout: Layout,
+  pageGap: number,
+  pageArrangement: PageArrangement,
+  viewportWidth: number
+): number {
+  if (pageArrangement === 'wrapped') {
+    const offsets = computePageVisualOffsets(layout, pageGap, pageArrangement, viewportWidth);
+    const pagesHeight = layout.pages.reduce((maxBottom, page, index) => {
+      const offset = offsets[index] ?? { top: 0, left: 0 };
+      return Math.max(maxBottom, offset.top + page.size.h);
+    }, 0);
+    return pagesHeight + VIEWPORT_PADDING_TOP + pageGap * 2 + 24;
+  }
+
   const n = layout.pages.length;
   const pagesHeight = layout.pages.reduce((sum, page) => sum + page.size.h, 0);
   return pagesHeight + Math.max(0, n - 1) * pageGap + VIEWPORT_PADDING_TOP + 24;
@@ -246,6 +322,8 @@ export interface PagedEditorProps {
   pageGap?: number;
   /** Zoom level (1 = 100%). */
   zoom?: number;
+  /** Page viewing mode for the visible canvas. */
+  pageViewMode?: PageViewMode;
   /** Callback when document changes. */
   onDocumentChange?: (document: Document) => void;
   /** Callback when selection changes. */
@@ -435,7 +513,8 @@ function computeAnchorPositions(
   layout: Layout,
   blocks: FlowBlock[],
   measures: Measure[],
-  renderedPageGap: number
+  renderedPageGap: number,
+  pageVisualOffsets?: PageVisualOffset[]
 ): Map<string, number> {
   const positions = new Map<string, number>();
   if (!pmView?.state) return positions;
@@ -469,7 +548,9 @@ function computeAnchorPositions(
       // Try exact position (paragraphs/images)
       const caret = getCaretPosition(layout, blocks, measures, pos);
       if (caret) {
-        positions.set(key, caret.y + contentOffset);
+        const layoutPageTop = getPageTop(layout, caret.pageIndex);
+        const visualPageTop = pageVisualOffsets?.[caret.pageIndex]?.top ?? layoutPageTop;
+        positions.set(key, caret.y - layoutPageTop + visualPageTop + contentOffset);
         continue;
       }
 
@@ -484,7 +565,8 @@ function computeAnchorPositions(
 
           const rowOffsetY =
             frag.kind === 'table' ? getTableRowOffset(blocks, measures, frag, pos) : 0;
-          positions.set(key, frag.y + rowOffsetY + getPageTop(layout, pi) + contentOffset);
+          const visualPageTop = pageVisualOffsets?.[pi]?.top ?? getPageTop(layout, pi);
+          positions.set(key, frag.y + rowOffsetY + visualPageTop + contentOffset);
           found = true;
           break;
         }
@@ -1232,6 +1314,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       readOnly = false,
       pageGap = DEFAULT_PAGE_GAP,
       zoom = 1,
+      pageViewMode = 'onePage',
       onDocumentChange,
       onSelectionChange,
       externalPlugins = EMPTY_PLUGINS,
@@ -1253,6 +1336,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onTotalPagesChange,
       resolvedCommentIds,
     } = props;
+    const pageArrangement = getPageArrangement(pageViewMode);
 
     // Resolve the scroll container: prefer parent-provided ref, fallback to own container
     const getScrollContainer = useCallback((): HTMLDivElement | null => {
@@ -1306,6 +1390,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
     // State
     const [layout, setLayout] = useState<Layout | null>(null);
+    const [viewportWidth, setViewportWidth] = useState(0);
     const lastTotalPagesRef = useRef<number>(0);
     const onTotalPagesChangeRef = useRef(onTotalPagesChange);
     onTotalPagesChangeRef.current = onTotalPagesChange;
@@ -1323,6 +1408,20 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const [isFocused, setIsFocused] = useState(false);
     const [selectionRects, setSelectionRects] = useState<SelectionRect[]>([]);
     const [caretPosition, setCaretPosition] = useState<CaretPosition | null>(null);
+
+    useLayoutEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const updateViewportWidth = () => {
+        setViewportWidth(container.clientWidth);
+      };
+      updateViewportWidth();
+
+      const observer = new ResizeObserver(updateViewportWidth);
+      observer.observe(container);
+      return () => observer.disconnect();
+    }, []);
 
     // Image selection state
     const [selectedImageInfo, setSelectedImageInfo] = useState<ImageSelectionInfo | null>(null);
@@ -1761,6 +1860,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               theme: _theme,
               footnotesByPage: footnotesByPage?.size ? footnotesByPage : undefined,
               resolvedCommentIds,
+              pageArrangement,
             } as RenderPageOptions & {
               pageGap?: number;
               blockLookup?: BlockLookup;
@@ -1769,7 +1869,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
             const vp = viewportLayoutRef.current;
             if (vp) {
-              const mh = viewportMinHeightPx(newLayout, pageGap);
+              const mh = viewportMinHeightPx(newLayout, pageGap, pageArrangement, viewportWidth);
               vp.style.minHeight = `${mh}px`;
               if (zoom !== 1) {
                 vp.style.marginBottom = `${mh * (zoom - 1)}px`;
@@ -1816,12 +1916,19 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           // Compute anchor Y positions for comments sidebar (works without DOM queries).
           // Only runs when the sidebar callback is registered.
           if (onAnchorPositionsChange) {
+            const pageVisualOffsets = computePageVisualOffsets(
+              newLayout,
+              pageGap,
+              pageArrangement,
+              viewportWidth
+            );
             const positions = computeAnchorPositions(
               hiddenPMRef.current?.getView() ?? null,
               newLayout,
               newBlocks,
               newMeasures,
-              pageGap
+              pageGap,
+              pageVisualOffsets
             );
             onAnchorPositionsChange(positions);
           }
@@ -1864,6 +1971,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         document,
         resolvedCommentIds,
         getScrollContainer,
+        pageArrangement,
+        viewportWidth,
       ]
     );
 
@@ -2143,19 +2252,27 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             const overlay = pagesContainerRef.current?.parentElement?.querySelector(
               '[data-testid="selection-overlay"]'
             );
-            const firstPage = pagesContainerRef.current?.querySelector('.layout-page');
 
-            if (overlay && firstPage) {
+            if (overlay && pagesContainerRef.current) {
               const overlayRect = overlay.getBoundingClientRect();
-              const pageRect = firstPage.getBoundingClientRect();
               const caret = getCaretPosition(layout, blocks, measures, from);
 
               if (caret) {
-                setCaretPosition({
-                  ...caret,
-                  x: caret.x + (pageRect.left - overlayRect.left) / zoom,
-                  y: caret.y + (pageRect.top - overlayRect.top) / zoom,
-                });
+                const pageEl =
+                  pagesContainerRef.current.querySelectorAll<HTMLElement>('.layout-page')[
+                    caret.pageIndex
+                  ];
+                if (!pageEl) {
+                  setCaretPosition(null);
+                } else {
+                  const pageRect = pageEl.getBoundingClientRect();
+                  const layoutPageTop = getPageTop(layout, caret.pageIndex);
+                  setCaretPosition({
+                    ...caret,
+                    x: caret.x + (pageRect.left - overlayRect.left) / zoom,
+                    y: caret.y - layoutPageTop + (pageRect.top - overlayRect.top) / zoom,
+                  });
+                }
               } else {
                 setCaretPosition(null);
               }
@@ -2248,18 +2365,25 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               setSelectionRects(domRects);
             } else {
               // Fallback to layout-based calculation
-              const firstPage = pagesContainerRef.current.querySelector('.layout-page');
-              if (firstPage) {
-                const pageRect = firstPage.getBoundingClientRect();
-                const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
-                const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
-
+              const pageEls =
+                pagesContainerRef.current.querySelectorAll<HTMLElement>('.layout-page');
+              if (pageEls.length > 0) {
                 const rects = selectionToRects(layout, blocks, measures, from, to);
-                const adjustedRects = rects.map((rect) => ({
-                  ...rect,
-                  x: rect.x + pageOffsetX,
-                  y: rect.y + pageOffsetY,
-                }));
+                const adjustedRects = rects.flatMap((rect) => {
+                  const pageEl = pageEls[rect.pageIndex];
+                  if (!pageEl) return [];
+                  const pageRect = pageEl.getBoundingClientRect();
+                  const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
+                  const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
+                  const layoutPageTop = getPageTop(layout, rect.pageIndex);
+                  return [
+                    {
+                      ...rect,
+                      x: rect.x + pageOffsetX,
+                      y: rect.y - layoutPageTop + pageOffsetY,
+                    },
+                  ];
+                });
                 setSelectionRects(adjustedRects);
               } else {
                 setSelectionRects([]);
@@ -3884,6 +4008,45 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       runLayoutPipeline,
     ]);
 
+    const previousPageArrangementRef = useRef(pageArrangement);
+    useEffect(() => {
+      if (previousPageArrangementRef.current === pageArrangement) return;
+      previousPageArrangementRef.current = pageArrangement;
+
+      const state = hiddenPMRef.current?.getState();
+      if (state) {
+        runLayoutPipeline(state);
+        updateSelectionOverlay(state);
+      }
+    }, [pageArrangement, runLayoutPipeline, updateSelectionOverlay]);
+
+    useEffect(() => {
+      if (!onAnchorPositionsChange || !layout) return;
+      const pageVisualOffsets = computePageVisualOffsets(
+        layout,
+        pageGap,
+        pageArrangement,
+        viewportWidth
+      );
+      const positions = computeAnchorPositions(
+        hiddenPMRef.current?.getView() ?? null,
+        layout,
+        blocks,
+        measures,
+        pageGap,
+        pageVisualOffsets
+      );
+      onAnchorPositionsChange(positions);
+    }, [
+      blocks,
+      layout,
+      measures,
+      onAnchorPositionsChange,
+      pageArrangement,
+      pageGap,
+      viewportWidth,
+    ]);
+
     // Re-compute selection overlay when the container resizes.
     // Page elements shift during window resize (centering, scrollbar changes),
     // causing caret/selection coordinates to become stale.
@@ -4011,10 +4174,21 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // Calculate total height for scroll
     const totalHeight = useMemo(() => {
       if (!layout) return DEFAULT_PAGE_HEIGHT + 48;
-      const numPages = layout.pages.length;
-      const pagesHeight = layout.pages.reduce((sum, page) => sum + page.size.h, 0);
-      return pagesHeight + (numPages - 1) * pageGap + 48;
-    }, [layout, pageGap]);
+      return viewportMinHeightPx(layout, pageGap, pageArrangement, viewportWidth);
+    }, [layout, pageArrangement, pageGap, viewportWidth]);
+    const renderedPagesContainerStyles = useMemo<CSSProperties>(() => {
+      const isWrapped = pageArrangement === 'wrapped';
+      return {
+        ...pagesContainerStyles,
+        flexDirection: isWrapped ? 'row' : 'column',
+        flexWrap: isWrapped ? 'wrap' : 'nowrap',
+        justifyContent: isWrapped ? 'center' : undefined,
+        alignItems: isWrapped ? 'flex-start' : 'center',
+        alignContent: isWrapped ? 'flex-start' : undefined,
+        width: '100%',
+        boxSizing: 'border-box',
+      };
+    }, [pageArrangement]);
 
     return (
       <div
@@ -4068,7 +4242,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           <div
             ref={pagesContainerRef}
             className={`paged-editor__pages${readOnly ? ' paged-editor--readonly' : ''}${hfEditMode ? ` paged-editor--hf-editing paged-editor--editing-${hfEditMode}` : ''}`}
-            style={pagesContainerStyles}
+            style={renderedPagesContainerStyles}
             onMouseDown={handlePagesMouseDown}
             onMouseMove={handlePagesMouseMove}
             onClick={handlePagesClick}


### PR DESCRIPTION
## Summary

Adds Word-style document view modes to the formatting toolbar:

- `One Page` keeps the existing vertical page stack as the default.
- `Multiple Pages` wraps pages side by side on wide viewports.
- `Page Width` computes a fit-to-width zoom and updates responsively.

This also updates page-adjacent chrome so wrapped layouts behave correctly:

- rulers track the first visible page in a wrapped row
- the floating add-comment button anchors to the selected page
- comment markers and the unified sidebar can use rendered page rails
- leaving `Page Width` restores the previous explicit zoom

Closes https://github.com/eigenpal/docx-editor/issues/464.

## Suggested Approach

This PR is based on the draft implementation first staged in `dancrew32/docx-editor#1`. It is meant as a concrete proposal for review, not as a final statement on the maintainers' design direction.

The core approach is to use rendered page geometry for UI surfaces that sit outside the document body, instead of assuming one centered page. That matters for `Multiple Pages`, where page 1 and page 2 can share the same vertical row but need different horizontal rails.

## Synthetic Before / After

Using the non-sensitive fixture `e2e/fixtures/issue-68-large.docx`:

- Before: pages stayed in one vertical column on wide viewports.
- After: `Multiple Pages` places page 2 beside page 1 and preserves click-to-type.
- Before: rulers/comment affordances could align to the wrong page rail.
- After: the ruler aligns to the first visible page, and selecting text on page 2 shows the add-comment button at page 2's right edge.
- After: `Page Width` fits the page to the viewport, and returning to `One Page` restores the prior explicit zoom.

## Validation

- `bun run typecheck`
- `bun run lint` passes with existing warnings
- targeted Playwright coverage for view modes, comment button anchoring, and comments sidebar behavior
- GitHub CI passed `lint` and `test` on the fork PR

Full local Playwright suite note: the default local port was occupied by another app, so validation used a temporary port-specific config. The full suite also surfaced unrelated existing failures in agent-bridge and formatting/color combination tests outside this PR's touched surface.
